### PR TITLE
remove obsolete null property fix

### DIFF
--- a/app/actions/targetAction.js
+++ b/app/actions/targetAction.js
@@ -21,13 +21,7 @@ export function SubmitTarget(treecounter, treecounterId) {
         headers: { Authorization: `Bearer ${window.localStorage.getItem('jwt')}` }
       })
       .then(res => {
-        const treecounterData = res.data;
-        // make sure key 'targetComment' is present in merge data even it has not been returned in response
-        treecounterData.target_comment =
-          'target_comment' in treecounterData
-            ? treecounterData.target_comment
-            : null;
-        dispatch(mergeEntities(normalize(treecounterData, treecounterSchema)));
+        dispatch(mergeEntities(normalize(res.data, treecounterSchema)));
         history.push(getLocalRoute('app_userHome'));
       })
       .catch(error => {


### PR DESCRIPTION
Objects serialized on the server, did not include properties when the value was NULL.
This has been fixed and from now on all JSON objects returned by the server will always include all properties.
The fix in `targetAction.js` is therefore obsolete now and has been removed.
Feel free to test and merge.