### PR TITLE
Session ids

### DIFF
--- a/app/stores/localStorage.js
+++ b/app/stores/localStorage.js
@@ -34,5 +34,7 @@ export const fetchItem = key => {
 };
 
 export const clearStorage = () => {
+  const sessionId = window.localStorage.getItem('session_id');
   window.localStorage.clear();
+  window.localStorage.setItem('session_id', sessionId);
 };


### PR DESCRIPTION
Request functions in app/utils/api.js will now send the header X-SESSION-ID in each request.
The corresponding value is generated once and held in local storage. 
In order to clear the  local storage, app/stores/localStorage.js::clearStorage() must be used as it now preserves the session id.

It might be a good idea to move the function `getSessionId()` to `localStorage.js` in order for the storage key (`'session_id'`) to be handled in a single place.

Please revise and merge into dev asap. I have tested without errors.