### PR TITLE
fix suggest url

### DIFF
--- a/app/components/Header/SearchAutosuggest.js
+++ b/app/components/Header/SearchAutosuggest.js
@@ -32,7 +32,7 @@ const profileType = {
 
 const getSuggestions = value => {
   return new Promise(resolve => {
-    postDirectRequest('suggest', 'q=' + value.trim()).then(result => {
+    postDirectRequest('/suggest', 'q=' + value.trim()).then(result => {
       let jdata = result.data;
       const escapedValue = escapeRegexCharacters(value.trim());
       if (escapedValue === '') {

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -74,8 +74,8 @@ export async function postRequest(route, data, params, authenticated = false) {
 
 export async function postDirectRequest(path, data, authenticated = false) {
   const { scheme, host } = context;
-  const serverName = `${scheme}:/${host}`;
-  const url = `${serverName}/${path}`;
+  const serverName = `${scheme}://${host}`;
+  const url = `${serverName}${path}`;
   return await axios
     .post(url, data, await getHeaders(authenticated))
     .then(checkStatus)


### PR DESCRIPTION
This should hopefully fix the problem discussed in chat where suggest URL was build as:
`https://www.trilliontreecampaign.org/www.trilliontreecampaign.org/suggest`