### PR TITLE
display event page even if total number of pledged tress is zero

### DIFF
--- a/app/components/Pledge/index.js
+++ b/app/components/Pledge/index.js
@@ -55,7 +55,7 @@ export default class Pledge extends Component {
   }
   render() {
     let { eventSlug } = this.props;
-    return this.props.pledges && this.props.pledges.total ? (
+    return this.props.pledges && this.props.pledges.total !== undefined ? (
       <div className="sidenav-wrapper app-container__content--center">
         <div className="conference_heading">
           <div className="esri_logo_background">


### PR DESCRIPTION
Currently Event Page does not render anything if total number of pledged trees is zero.