### PR TITLE
Fix/missing title resource

### DIFF
--- a/app/locales/de/signUplabels.json
+++ b/app/locales/de/signUplabels.json
@@ -21,5 +21,6 @@
   "education_title": "Schule",
   "already_have_account": "Haben Sie schon ein Konto?",
   "education": "Bildung",
-  "organization": "Organisation"
+  "organization": "Organisation",
+  "title": "Titel"
 }

--- a/app/locales/en/signUplabels.json
+++ b/app/locales/en/signUplabels.json
@@ -21,5 +21,6 @@
   "education_title": "School",
   "already_have_account": "Already have an account?",
   "education": "Education",
-  "organization": "Organization"
+  "organization": "Organization",
+  "title": "Title"
 }


### PR DESCRIPTION
It think there was a "title" label missing for editing the user profile (which is not requested for signing up and therefore had been forgotten):

<img width="695" alt="Bildschirmfoto 2019-05-21 um 14 37 37" src="https://user-images.githubusercontent.com/1532418/58096836-3f7ec080-7bd6-11e9-8467-01368e23d4a8.png">
