### PR TITLE
regenerated index.js for translations

### DIFF
--- a/app/locales/de/index.js
+++ b/app/locales/de/index.js
@@ -1,52 +1,69 @@
+import activateAccountlabels from './activateAccountlabels.json';
+import challengelabels from './challengelabels.json';
+import commonlabels from './commonlabels.json';
+import competitionlabels from './competitionlabels.json';
+import dedicateTreeslabels from './dedicateTreeslabels.json';
+import donateTreeslabels from './donateTreeslabels.json';
+import editUserProfilelabels from './editUserProfilelabels.json';
+import emailSentActivationlabels from './emailSentActivationlabels.json';
+import emailSentlabels from './emailSentlabels.json';
+import faqlabels from './faqlabels.json';
+import footerlabels from './footerlabels.json';
+import forgotPasswordlabels from './forgotPasswordlabels.json';
+import giftTreeslabels from './giftTreeslabels.json';
+import headerlabels from './headerlabels.json';
+import leaderboradlabels from './leaderboradlabels.json';
+import loginlabels from './loginlabels.json';
+import manageProjectlabels from './manageProjectlabels.json';
 import menulabels from './menulabels.json';
+import paymentlabels from './paymentlabels.json';
 import plantProjectlabels from './plantProjectlabels.json';
+import pledgelabels from './pledgelabels.json';
+import publicTreecounterlabels from './publicTreecounterlabels.json';
+import redemptionlabels from './redemptionlabels.json';
 import registerTreeslabels from './registerTreeslabels.json';
-import signUplabels from './signUplabels.json';
+import selectPlantProjectlabels from './selectPlantProjectlabels.json';
 import signUpSuccessfullabels from './signUpSuccessfullabels.json';
+import signUplabels from './signUplabels.json';
 import targetlabels from './targetlabels.json';
 import tpoProjectlabels from './tpoProjectlabels.json';
 import treecounterGraphicslabels from './treecounterGraphicslabels.json';
 import userContributionslabels from './userContributionslabels.json';
-import headerlabels from './headerlabels.json';
-import loginlabels from './loginlabels.json';
-import activateAccountlabels from './activateAccountlabels.json';
-import commonlabels from './commonlabels.json';
-import donateTreeslabels from './donateTreeslabels.json';
-import emailSentlabels from './emailSentlabels.json';
-import faqlabels from './faqlabels.json';
-import forgotPasswordlabels from './forgotPasswordlabels.json';
-import giftTreeslabels from './giftTreeslabels.json';
-import leaderboradlabels from './leaderboradlabels.json';
-import paymentlabels from './paymentlabels.json';
-import publicTreecounterlabels from './publicTreecounterlabels.json';
-import editUserProfilelabels from './editUserProfilelabels.json';
-import selectPlantProjectlabels from './selectPlantProjectlabels.json';
-import pledgelabels from './pledgelabels.json';
-import footerlabels from './footerlabels.json';
+import welcomeScreenlabels from './welcomeScreenlabels.json';
+import widgetShareLabels from './widgetShareLabels.json';
+
 export default {
-  ...loginlabels,
+  ...activateAccountlabels,
+  ...challengelabels,
+  ...commonlabels,
+  ...competitionlabels,
+  ...dedicateTreeslabels,
+  ...donateTreeslabels,
+  ...editUserProfilelabels,
+  ...emailSentActivationlabels,
+  ...emailSentlabels,
+  ...faqlabels,
+  ...footerlabels,
+  ...forgotPasswordlabels,
+  ...giftTreeslabels,
   ...headerlabels,
+  ...leaderboradlabels,
+  ...loginlabels,
+  ...manageProjectlabels,
   ...menulabels,
+  ...paymentlabels,
   ...plantProjectlabels,
+  ...pledgelabels,
+  ...publicTreecounterlabels,
+  ...redemptionlabels,
   ...registerTreeslabels,
-  ...signUplabels,
+  ...selectPlantProjectlabels,
   ...signUpSuccessfullabels,
+  ...signUplabels,
   ...targetlabels,
   ...tpoProjectlabels,
   ...treecounterGraphicslabels,
   ...userContributionslabels,
-  ...activateAccountlabels,
-  ...commonlabels,
-  ...donateTreeslabels,
-  ...emailSentlabels,
-  ...faqlabels,
-  ...forgotPasswordlabels,
-  ...giftTreeslabels,
-  ...leaderboradlabels,
-  ...paymentlabels,
-  ...publicTreecounterlabels,
-  ...editUserProfilelabels,
-  ...selectPlantProjectlabels,
-  ...pledgelabels,
-  ...footerlabels
+  ...welcomeScreenlabels,
+  ...widgetShareLabels
 };

--- a/app/locales/en/index.js
+++ b/app/locales/en/index.js
@@ -1,69 +1,69 @@
+import activateAccountlabels from './activateAccountlabels.json';
+import challengelabels from './challengelabels.json';
+import commonlabels from './commonlabels.json';
+import competitionlabels from './competitionlabels.json';
+import dedicateTreeslabels from './dedicateTreeslabels.json';
+import donateTreeslabels from './donateTreeslabels.json';
+import editUserProfilelabels from './editUserProfilelabels.json';
+import emailSentActivationlabels from './emailSentActivationlabels.json';
+import emailSentlabels from './emailSentlabels.json';
+import faqlabels from './faqlabels.json';
+import footerlabels from './footerlabels.json';
+import forgotPasswordlabels from './forgotPasswordlabels.json';
+import giftTreeslabels from './giftTreeslabels.json';
+import headerlabels from './headerlabels.json';
+import leaderboradlabels from './leaderboradlabels.json';
+import loginlabels from './loginlabels.json';
+import manageProjectlabels from './manageProjectlabels.json';
 import menulabels from './menulabels.json';
+import paymentlabels from './paymentlabels.json';
 import plantProjectlabels from './plantProjectlabels.json';
+import pledgelabels from './pledgelabels.json';
+import publicTreecounterlabels from './publicTreecounterlabels.json';
+import redemptionlabels from './redemptionlabels.json';
 import registerTreeslabels from './registerTreeslabels.json';
-import signUplabels from './signUplabels.json';
+import selectPlantProjectlabels from './selectPlantProjectlabels.json';
 import signUpSuccessfullabels from './signUpSuccessfullabels.json';
+import signUplabels from './signUplabels.json';
 import targetlabels from './targetlabels.json';
 import tpoProjectlabels from './tpoProjectlabels.json';
 import treecounterGraphicslabels from './treecounterGraphicslabels.json';
 import userContributionslabels from './userContributionslabels.json';
-import headerlabels from './headerlabels.json';
-import loginlabels from './loginlabels.json';
-import activateAccountlabels from './activateAccountlabels.json';
-import commonlabels from './commonlabels.json';
-import donateTreeslabels from './donateTreeslabels.json';
-import emailSentlabels from './emailSentlabels.json';
-import faqlabels from './faqlabels.json';
-import forgotPasswordlabels from './forgotPasswordlabels.json';
-import giftTreeslabels from './giftTreeslabels.json';
-import leaderboradlabels from './leaderboradlabels.json';
-import paymentlabels from './paymentlabels.json';
-import publicTreecounterlabels from './publicTreecounterlabels.json';
-import editUserProfilelabels from './editUserProfilelabels.json';
-import selectPlantProjectlabels from './selectPlantProjectlabels.json';
-import pledgelabels from './pledgelabels.json';
-import redemptionlables from './redemptionlabels.json';
-import footerlabels from './footerlabels.json';
 import welcomeScreenlabels from './welcomeScreenlabels.json';
-import emailSendActivationlabels from './emailSentActivationlabels.json';
-import competitionlabels from './competitionlabels.json';
-import challengelabels from './challengelabels.json';
-import manageProjectlabels from './manageProjectlabels.json';
 import widgetShareLabels from './widgetShareLabels.json';
-import dedicateTreesLabels from './dedicateTreeslabels';
 
 export default {
-  ...loginlabels,
+  ...activateAccountlabels,
+  ...challengelabels,
+  ...commonlabels,
+  ...competitionlabels,
+  ...dedicateTreeslabels,
+  ...donateTreeslabels,
+  ...editUserProfilelabels,
+  ...emailSentActivationlabels,
+  ...emailSentlabels,
+  ...faqlabels,
+  ...footerlabels,
+  ...forgotPasswordlabels,
+  ...giftTreeslabels,
   ...headerlabels,
+  ...leaderboradlabels,
+  ...loginlabels,
+  ...manageProjectlabels,
   ...menulabels,
+  ...paymentlabels,
   ...plantProjectlabels,
+  ...pledgelabels,
+  ...publicTreecounterlabels,
+  ...redemptionlabels,
   ...registerTreeslabels,
-  ...signUplabels,
+  ...selectPlantProjectlabels,
   ...signUpSuccessfullabels,
+  ...signUplabels,
   ...targetlabels,
   ...tpoProjectlabels,
   ...treecounterGraphicslabels,
   ...userContributionslabels,
-  ...activateAccountlabels,
-  ...commonlabels,
-  ...donateTreeslabels,
-  ...emailSentlabels,
-  ...faqlabels,
-  ...forgotPasswordlabels,
-  ...giftTreeslabels,
-  ...leaderboradlabels,
-  ...paymentlabels,
-  ...publicTreecounterlabels,
-  ...editUserProfilelabels,
-  ...selectPlantProjectlabels,
-  ...pledgelabels,
-  ...redemptionlables,
-  ...footerlabels,
   ...welcomeScreenlabels,
-  ...emailSendActivationlabels,
-  ...competitionlabels,
-  ...challengelabels,
-  ...manageProjectlabels,
-  ...widgetShareLabels,
-  ...dedicateTreesLabels
+  ...widgetShareLabels
 };

--- a/app/locales/es/index.js
+++ b/app/locales/es/index.js
@@ -1,52 +1,69 @@
+import activateAccountlabels from './activateAccountlabels.json';
+import challengelabels from './challengelabels.json';
+import commonlabels from './commonlabels.json';
+import competitionlabels from './competitionlabels.json';
+import dedicateTreeslabels from './dedicateTreeslabels.json';
+import donateTreeslabels from './donateTreeslabels.json';
+import editUserProfilelabels from './editUserProfilelabels.json';
+import emailSentActivationlabels from './emailSentActivationlabels.json';
+import emailSentlabels from './emailSentlabels.json';
+import faqlabels from './faqlabels.json';
+import footerlabels from './footerlabels.json';
+import forgotPasswordlabels from './forgotPasswordlabels.json';
+import giftTreeslabels from './giftTreeslabels.json';
+import headerlabels from './headerlabels.json';
+import leaderboradlabels from './leaderboradlabels.json';
+import loginlabels from './loginlabels.json';
+import manageProjectlabels from './manageProjectlabels.json';
 import menulabels from './menulabels.json';
+import paymentlabels from './paymentlabels.json';
 import plantProjectlabels from './plantProjectlabels.json';
+import pledgelabels from './pledgelabels.json';
+import publicTreecounterlabels from './publicTreecounterlabels.json';
+import redemptionlabels from './redemptionlabels.json';
 import registerTreeslabels from './registerTreeslabels.json';
-import signUplabels from './signUplabels.json';
+import selectPlantProjectlabels from './selectPlantProjectlabels.json';
 import signUpSuccessfullabels from './signUpSuccessfullabels.json';
+import signUplabels from './signUplabels.json';
 import targetlabels from './targetlabels.json';
 import tpoProjectlabels from './tpoProjectlabels.json';
 import treecounterGraphicslabels from './treecounterGraphicslabels.json';
 import userContributionslabels from './userContributionslabels.json';
-import headerlabels from './headerlabels.json';
-import loginlabels from './loginlabels.json';
-import activateAccountlabels from './activateAccountlabels.json';
-import commonlabels from './commonlabels.json';
-import donateTreeslabels from './donateTreeslabels.json';
-import emailSentlabels from './emailSentlabels.json';
-import faqlabels from './faqlabels.json';
-import forgotPasswordlabels from './forgotPasswordlabels.json';
-import giftTreeslabels from './giftTreeslabels.json';
-import leaderboradlabels from './leaderboradlabels.json';
-import paymentlabels from './paymentlabels.json';
-import publicTreecounterlabels from './publicTreecounterlabels.json';
-import editUserProfilelabels from './editUserProfilelabels.json';
-import selectPlantProjectlabels from './selectPlantProjectlabels.json';
-import pledgelabels from './pledgelabels.json';
-import footerlabels from './footerlabels.json';
+import welcomeScreenlabels from './welcomeScreenlabels.json';
+import widgetShareLabels from './widgetShareLabels.json';
+
 export default {
-  ...loginlabels,
+  ...activateAccountlabels,
+  ...challengelabels,
+  ...commonlabels,
+  ...competitionlabels,
+  ...dedicateTreeslabels,
+  ...donateTreeslabels,
+  ...editUserProfilelabels,
+  ...emailSentActivationlabels,
+  ...emailSentlabels,
+  ...faqlabels,
+  ...footerlabels,
+  ...forgotPasswordlabels,
+  ...giftTreeslabels,
   ...headerlabels,
+  ...leaderboradlabels,
+  ...loginlabels,
+  ...manageProjectlabels,
   ...menulabels,
+  ...paymentlabels,
   ...plantProjectlabels,
+  ...pledgelabels,
+  ...publicTreecounterlabels,
+  ...redemptionlabels,
   ...registerTreeslabels,
-  ...signUplabels,
+  ...selectPlantProjectlabels,
   ...signUpSuccessfullabels,
+  ...signUplabels,
   ...targetlabels,
   ...tpoProjectlabels,
   ...treecounterGraphicslabels,
   ...userContributionslabels,
-  ...activateAccountlabels,
-  ...commonlabels,
-  ...donateTreeslabels,
-  ...emailSentlabels,
-  ...faqlabels,
-  ...forgotPasswordlabels,
-  ...giftTreeslabels,
-  ...leaderboradlabels,
-  ...paymentlabels,
-  ...publicTreecounterlabels,
-  ...editUserProfilelabels,
-  ...selectPlantProjectlabels,
-  ...pledgelabels,
-  ...footerlabels
+  ...welcomeScreenlabels,
+  ...widgetShareLabels
 };


### PR DESCRIPTION
I just regenerated all three (de/en/es) `index.js` files for all translation resource files available (in alphabetical order) and therefore also fixed the errors with the wrongly imported `dedicateTreesLabels` resource file and all the missing imports for the German (or Spanish) resources files.

This could fix some of the errors of the translation issues I created https://github.com/Plant-for-the-Planet-org/treecounter-app/issues?q=is%3Aissue+is%3Aopen+label%3Atranslation - but as I am not in the office I do not have my local sandboxes and are not able to test this patch. 

@niteshgrg Can you please test this patch and apply it if it helps to fix some of the issues?