### PR TITLE
use smaller font for search cancel button as German translation requi…

### DIFF
--- a/app/components/Header/SearchBar.native.js
+++ b/app/components/Header/SearchBar.native.js
@@ -139,6 +139,7 @@ class SearchBar extends React.PureComponent {
               onPress={this._handlePressCancelButton}
             >
               <Text
+                numberOfLines={1}
                 style={{
                   fontSize: 14,
                   color: this.props.tintColor || '#007AFF',


### PR DESCRIPTION
This is just a suggestion to make the cancel button of the global search a little bit smaller in order to allow the German translation "Abbrechen" being shown without truncation. Please test on your device (I just tested an iPhoneX, Galaxy S6 Edge and Pixel Emulator).

![Simulator Screen Shot - iPhone X - 2019-06-17 at 11 30 27](https://user-images.githubusercontent.com/1532418/59594035-593af700-90f3-11e9-96d9-f941780dc6ee.png)
