### PR TITLE
Fixed Bug: where register tree map sending same latitude and longitude

### DIFF
--- a/app/components/Map/MapContributionCapture.js
+++ b/app/components/Map/MapContributionCapture.js
@@ -100,7 +100,7 @@ class MapContributionCapture extends React.Component {
             view.goTo(result.extent).then(() => {
               const geoLocation = {
                 geoLongitude: result.extent.center.longitude,
-                geoLatitude: result.extent.center.longitude,
+                geoLatitude: result.extent.center.latitude,
                 countryCode: result.feature.attributes.CountryCode
               };
               this.setState({ geoLocation });


### PR DESCRIPTION
The issue was in the loa level Map component not in the map template 