### PR TITLE
fix #927 adding a safety check for treeIds parameter

### DIFF
--- a/app/components/Common/SvgContainer.js
+++ b/app/components/Common/SvgContainer.js
@@ -273,10 +273,14 @@ export default class SvgContainer extends Component {
   }
 
   getTreeIdsFromPercentage(treeIds, percentage) {
-    const countIndexes = treeIds.length - 1;
-    const index = Math.round(percentage * countIndexes);
+    if (treeIds) {
+      const countIndexes = treeIds.length - 1;
+      const index = Math.round(percentage * countIndexes);
 
-    return treeIds.slice(0, index);
+      return treeIds.slice(0, index);
+    } else {
+      return null;
+    }
   }
 
   renderTreesById(treeIds, type, group) {


### PR DESCRIPTION
Try to fix #927 - my problem about this is, I can not reproduce this issue locally where the parameter "treeIds" is null and therefore can not check what happens when the functions return null (i.d. if anything unexpected would happen afterwards).