### PR TITLE
Fix: this.refs.slider is undefined in donateTrees

### DIFF
--- a/app/components/DonateTrees/index.js
+++ b/app/components/DonateTrees/index.js
@@ -307,12 +307,14 @@ export default class DonateTrees extends Component {
   }
 
   render() {
+    // this is just for NextArrow displayNone
     let displayNone = classNames({
       'display-none': this.state.pageIndex === 3
     });
+
     if (this.refs.slider) {
       setTimeout(() => {
-        if (this.state.pageIndex === 3) {
+        if (this.refs.slider && this.state.pageIndex === 3) {
           this.refs.slider.slickGoTo(this.state.pageIndex);
         }
       }, 1000);
@@ -369,9 +371,11 @@ export default class DonateTrees extends Component {
           } else {
             if (this.refs.slider) {
               setTimeout(() => {
-                this.refs.slider.slickGoTo(
-                  !oldIndexCheck ? oldIndex : index - 1
-                );
+                if (this.refs.slider) {
+                  this.refs.slider.slickGoTo(
+                    !oldIndexCheck ? oldIndex : index - 1
+                  );
+                }
               }, 1000);
             }
           }


### PR DESCRIPTION
It is possible that after the 1000ms `setTimeout` that the slider no longer exists.
The component may be closed because the user navigated away.

Fixes: #1028 (at line 372)
Fixes: #933 (at line

I did try to replicate the bug by thrashing around the app but never really got it to happen. I did see this.refs.slider going back to undefined. 

In any case, if you use a `setTimeout` (which is always risky in `React` land) then you have to check your variables inside the timeout function.

