### PR TITLE
rename branch dev to test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         - master
         - staging
         - devel
-        - dev
+        - test
     docker:
       - image: alpine
 
@@ -39,7 +39,7 @@ jobs:
             then
               echo 'export WD_REACT="$PROJ_DIR/ttc-app_devel"' >>  $ENV_VARS
               echo 'export WD_SYMFONY="$PROJ_DIR/ttc2018_devel"' >>  $ENV_VARS
-            elif [[ "${CIRCLE_BRANCH}" == "dev" ]]
+            elif [[ "${CIRCLE_BRANCH}" == "test" ]]
             then
               echo 'export WD_REACT="$PROJ_DIR/ttc-app_test"' >>  $ENV_VARS
               echo 'export WD_SYMFONY="$PROJ_DIR/ttc2018_test"' >>  $ENV_VARS


### PR DESCRIPTION
I would like to rename the branch `dev` to `test` in our app repository to match the naming in the other repositories and the server namings. I already (1) prepared the integration job of the test branch in the TTC backend repository to support the new name by https://github.com/Plant-for-the-Planet-org/treecounter-platform/commit/1eee807445d0fa46920b6aa59ba4b8f2ce339e07 and (2) also changed the Dashboard to the new name by https://github.com/Plant-for-the-Planet-org/dashboard/commit/137ad2bcee5ee7fee1c85128f327686ece700001. (3) I created a branch named `test` on the same level as the current branch `dev`. Last thing to do would be to merge this pull request into all main branches (I also added a branch protection rule for `test` next to `dev`.)