### PR TITLE
Document initial config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 `index.web.js` is the entry point of web platform build, `index.js` is the entry point of both iOS and android platform build process.
 
+## Configuration
+
+Copy `app/config/index.js.dist` to `app/config/index.js`.
+
 ## Web Setup
 
 Run following commands

--- a/app/config/index.js.dist
+++ b/app/config/index.js.dist
@@ -14,7 +14,7 @@ export const initialProps = {
 export const context = {
   scheme: 'https', // API server protocol
   host: 'test.trilliontreecampaign.org', // API server domain
-  base: '/app_dev.php', // debug mode on/off, set to empty string to switch debug mode off
+  base: '',  // API base url. Debug mode off: "" on: "/app_dev.php" (requires login)
   debug: true, // local console debugging switch
   currency: 'USD',
   mapIds: { inventory: 'dee6acf9de774fe6878813f707b4ab88'}


### PR DESCRIPTION
This seems really small, but it took me 15 minutes of sniffing around to figure out what was going on. 

The first thing a dev needs to do is copy that file, and the suggested default requires a user account on the API server.