### PR TITLE
Fix #1007 - protect against non-existing donateReceipt Form

### DIFF
--- a/app/components/DonateTrees/index.js
+++ b/app/components/DonateTrees/index.js
@@ -198,7 +198,7 @@ export default class DonateTrees extends Component {
     },
     () => {
       // console.log(this.refs.donateReceipt.validate());
-      let value = this.refs.donateReceipt.getValue();
+      let value = this.refs.donateReceipt && this.refs.donateReceipt.getValue();
       let receipt = {};
       if (value) {
         if (this.state.modeReceipt === 'individual') {
@@ -236,7 +236,7 @@ export default class DonateTrees extends Component {
     },
     () => {
       // console.log(this.refs.donateReceipt.validate());
-      let value = this.refs.donateReceipt.getValue();
+      let value = this.refs.donateReceipt && this.refs.donateReceipt.getValue();
       let receipt = {};
       if (value) {
         if (this.state.modeReceipt === 'individual') {


### PR DESCRIPTION
When a payment error occurs the user is offered a "TRY AGAIN" button which kicks them back to form page 3 (pageIndex=2) but there is not yet a receipt form rendered. This throws an error due to `this.refs.donateReceipt` being undefined.

This PR simply protects against the undefined ref for now. This means that the user goes back to pageIndex=2, does NOT have an error, the form renders as planned and then they can click Next to go to the Payment screen. They can complete the transaction.

Ideally the multi-page form should handle state and validation better.

The full solution is to rework this form so transaction and validation state is not intertwined with component rendering and display.  I would recommend we break this component up into smaller parts so we can eliminate all these possible error conditions and `setTimeouts`.

At least for now the customer transaction doesn't die and they can complete it.

How to replicate the error (do this on staging before trying the PR):

- Go to Donate Trees, fill out all pages except the last payment details
- Click PAY even though you haven't given any CC details
- API server throws a 500:
    An error has occurred processing your payment
    Must provide source or customer.

    TRY AGAIN
 - Click TRY AGAIN
   
- Now `this.refs.donateReceipt` is undefined because slideIndex is 2 (name address etc.) but there is no component yet rendered. 1000ms later there will be.

