### PR TITLE
Fix unhandled rejection in getAccessToken

### DIFF
--- a/app/actions/treecounterLookupAction.js
+++ b/app/actions/treecounterLookupAction.js
@@ -11,7 +11,7 @@ export function treecounterLookupAction(treecounterId, navigation = undefined) {
     // if so we de-normalize and just return it
     if (!treecounterId) {
       updateRoute('app_homepage', navigation || dispatch);
-      return Promise.reject('user not available');
+      return Promise.reject(new Error('user not available'));
     }
     return new Promise(function(resolve) {
       const entities = getState().entities;

--- a/app/helpers/utils.js
+++ b/app/helpers/utils.js
@@ -177,7 +177,7 @@ export function getSuggestions(value) {
       if (jdata) {
         resolve(jdata.filter(person => regex.test(getSuggestionValue(person))));
       } else {
-        reject(jdata);
+        reject(new Error(`/suggest returned nothing: ${jdata}`));
       }
     });
   });

--- a/app/stores/localStorage.js
+++ b/app/stores/localStorage.js
@@ -7,7 +7,7 @@ export const loadState = () => {
       }
       resolve(JSON.parse(serializedState));
     } catch (err) {
-      reject(null);
+      reject(err);
     }
   });
 };
@@ -28,7 +28,7 @@ export const fetchItem = key => {
     if (window.localStorage.getItem(key)) {
       resolve(window.localStorage.getItem(key));
     } else {
-      reject('Key not found');
+      reject(new Error(`${key} not in localStorage`));
     }
   });
 };

--- a/app/stores/localStorage.js
+++ b/app/stores/localStorage.js
@@ -25,12 +25,23 @@ export const saveItem = (key, value) => {
 
 export const fetchItem = key => {
   return new Promise(function(resolve, reject) {
-    if (window.localStorage.getItem(key)) {
-      resolve(window.localStorage.getItem(key));
-    } else {
+    const got = window.localStorage.getItem(key);
+    if (got === null) {
       reject(new Error(`${key} not in localStorage`));
+    } else {
+      resolve(got);
     }
   });
+};
+
+/**
+ * Get a possibly unset localStorage item.
+ * Use this when it is not an error for the item to be unset.
+ *
+ * @returns string | null
+ */
+export const getItem = key => {
+  return window.localStorage.getItem(key);
 };
 
 export const clearStorage = () => {

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -1,25 +1,22 @@
-import { fetchItem, saveItem } from '../stores/localStorage';
 import jwtDecode from 'jwt-decode';
-import { postRequest } from './api';
-import { email } from '../assets';
 
-export const getAccessToken = () => {
-  return fetchItem('token')
-    .then(async token => {
-      let expired = await tokenIsExpired();
-      if (expired) {
-        const prev_refresh_token = await fetchItem('refresh_token');
-        const response = await postRequest('gesdinet_jwt_refresh_token', {
-          refresh_token: prev_refresh_token
-        });
-        const { token, refresh_token } = response.data;
-        updateJWT(token, refresh_token);
-        return token;
-      } else {
-        return token;
-      }
-    })
-    .catch(err => console.log(err));
+import { fetchItem, getItem, saveItem } from '../stores/localStorage';
+import { postRequest } from './api';
+
+/**
+ * @returns string | null
+ */
+export const getAccessToken = async () => {
+  const token = getItem('token');
+  if (token) {
+    // This may throw an Error if localStorage is broken
+    // or POST requests timeout
+    const newToken = await refreshTokenIfExpired();
+    if (newToken) {
+      return newToken;
+    }
+  }
+  return token;
 };
 
 export const updateJWT = (token, refresh_token) => {
@@ -37,6 +34,22 @@ export const updateActivateToken = (email, activate_token) => {
 const getExpirationTimeStamp = token => {
   const { iat, exp } = jwtDecode(token);
   return getCurrentUnixTimestamp() + exp - iat;
+};
+
+/**
+ * @returns string | void
+ */
+const refreshTokenIfExpired = async () => {
+  if (await tokenIsExpired()) {
+    const prev_refresh_token = await fetchItem('refresh_token');
+    const response = await postRequest('gesdinet_jwt_refresh_token', {
+      refresh_token: prev_refresh_token
+    });
+    const newToken = response.data.token;
+    const refreshToken = response.data.refresh_token;
+    updateJWT(newToken, refreshToken);
+    return newToken;
+  }
 };
 
 const tokenIsExpired = async () => {


### PR DESCRIPTION
I think this is responsible for many of these errors:
https://app.bugsnag.com/plant-for-the-planet/plant-for-the-planet-app/errors/5d05f81ab3cb100019330da9?filters[event.since][0]=30d&filters[error.status][0]=open

1. Always reject with an `Error` — this is how bugsnag gets it's stack trace.

2. In `getAccessToken` there can be Errors thrown inside a `.then` handler which aren't handled at all. Fortunately modern browsers and Node will actually complain about those. It used to be they were swallowed and the dev never knew anything was wrong. But that's why the bugsnag reports don't have stack traces and just say things like "Timeout"

So now if something goes wrong in there, we will get an Error (will hit the error boundary) and a stack trace.

Or, we could catch errors there and at least log them, but then:

```js
// Could catch them here and log out the user,
// but then we would never know what happened.
// Otherwise the error propagates
try {
  // then this may fail. The user is then considered logged out.
  const newToken = await refreshTokenIfExpired();
  if (newToken) {
    return newToken;
  }
} catch (error) {
  // but if we made any mistake in our code, we will never know about it
  console.log(error);
  return null;
}
```
