### PR TITLE
added basic hound config to get rid of ES6 warnings

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+eslint:
+  ignore_file: .eslintignore
+
+jshint:
+  config_file: .jshintrc

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,1 @@
+{ "esversion":6 }


### PR DESCRIPTION
This hopefully helps to get rid of the warning about ES6 errors from the Hound integration.