### PR TITLE
Fix: Unhandled Errors thrown inside a .then() handler in getAccessToken

### DIFF
--- a/app/stores/localStorage.js
+++ b/app/stores/localStorage.js
@@ -26,12 +26,22 @@ export const saveItem = (key, value) => {
 export const fetchItem = key => {
   return new Promise(function(resolve, reject) {
     const got = window.localStorage.getItem(key);
-    if (got) {
-      resolve(got);
-    } else {
+    if (got === null) {
       reject(new Error(`${key} not in localStorage`));
+    } else {
+      resolve(got);
     }
   });
+};
+
+/**
+ * Get a possibly unset localStorage item.
+ * Use this when it is not an error for the item to be unset.
+ *
+ * @returns string | null
+ */
+export const getItem = async key => {
+  return window.localStorage.getItem(key);
 };
 
 export const clearStorage = () => {

--- a/app/stores/localStorage.native.js
+++ b/app/stores/localStorage.native.js
@@ -35,6 +35,16 @@ export const fetchItem = async key => {
   }
 };
 
+/**
+ * Get a possibly unset localStorage item.
+ * Use this when it is not an error for the item to be unset.
+ *
+ * @returns string | null
+ */
+export const getItem = async key => {
+  return await AsyncStorage.getItem(key);
+};
+
 export const clearStorage = async () => {
   const welcomeKey = await fetchItem('welcome');
   //console.log(welcomeKey);

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -42,9 +42,17 @@ const getExpirationTimeStamp = token => {
 const refreshTokenIfExpired = async () => {
   if (await tokenIsExpired()) {
     const prev_refresh_token = await fetchItem('refresh_token');
-    const response = await postRequest('gesdinet_jwt_refresh_token', {
-      refresh_token: prev_refresh_token
-    });
+    let response;
+    try {
+      response = await postRequest('gesdinet_jwt_refresh_token', {
+        refresh_token: prev_refresh_token
+      });
+    } catch (error) {
+      // 400
+      console.log(`Failed to refresh token: ${error}`);
+      return;
+    }
+
     const newToken = response.data.token;
     const refreshToken = response.data.refresh_token;
     updateJWT(newToken, refreshToken);

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -1,33 +1,22 @@
-import { fetchItem, saveItem } from '../stores/localStorage';
 import jwtDecode from 'jwt-decode';
-import { postRequest } from './api';
-import { email } from '../assets';
 
-export const getAccessToken = () => {
-  return fetchItem('token')
-    .then(async token => {
-      try {
-        let expired = await tokenIsExpired();
-        if (expired) {
-          const prev_refresh_token = await fetchItem('refresh_token');
-          const response = await postRequest('gesdinet_jwt_refresh_token', {
-            refresh_token: prev_refresh_token
-          });
-          const { token, refresh_token } = response.data;
-          updateJWT(token, refresh_token);
-          return token;
-        } else {
-          return token;
-        }
-      } catch (err) {
-        console.log(err);
-        return null;
-      }
-    })
-    .catch(err => {
-      console.log(err);
-      return null;
-    });
+import { fetchItem, getItem, saveItem } from '../stores/localStorage';
+import { postRequest } from './api';
+
+/**
+ * @returns string | null
+ */
+export const getAccessToken = async () => {
+  const token = await getItem('token');
+  if (token) {
+    // This may throw an Error if localStorage is broken
+    // or POST requests timeout
+    const newToken = await refreshTokenIfExpired();
+    if (newToken) {
+      return newToken;
+    }
+  }
+  return token;
 };
 
 export const updateJWT = (token, refresh_token) => {
@@ -45,6 +34,22 @@ export const updateActivateToken = (email, activate_token) => {
 const getExpirationTimeStamp = token => {
   const { iat, exp } = jwtDecode(token);
   return getCurrentUnixTimestamp() + exp - iat;
+};
+
+/**
+ * @returns string | void
+ */
+const refreshTokenIfExpired = async () => {
+  if (await tokenIsExpired()) {
+    const prev_refresh_token = await fetchItem('refresh_token');
+    const response = await postRequest('gesdinet_jwt_refresh_token', {
+      refresh_token: prev_refresh_token
+    });
+    const newToken = response.data.token;
+    const refreshToken = response.data.refresh_token;
+    updateJWT(newToken, refreshToken);
+    return newToken;
+  }
 };
 
 const tokenIsExpired = async () => {


### PR DESCRIPTION
This fixes minor issues in `app/utils/user.js` `getAccessToken` (used for logging in and session management)

There are many reported errors coming from `/login`:

https://app.bugsnag.com/plant-for-the-planet/plant-for-the-planet-app/errors/5d05f81ab3cb100019330da9?filters[search][0][type]=eq&filters[search][0][value]=UnhandledRejection

```
3 hours ago Aug 2nd, 20:48:44 UTC 
UnhandledRejection/login
Rejection reason was not an Error. See "Promise" tab for more detail.
rejection reason
undefined (or null)
(No stack trace)
```

This PR doesn't attempt to fix the error - it is just to supply an Error and get a stack trace so we know what the error is so it can then be fixed. 

Could be:
- localStorage failure (web or react-native), 
- API post request timeout.
- Unknown unknown

It was previously submitted and merged: https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/1090 

This was missing one function in `localStorage.native.js`

@norbertschuler reverted the commit in: https://github.com/Plant-for-the-Planet-org/treecounter-app/commit/ceae9845197883ac6d5b3718e0c6b0979138951d
and then there were several other attempts (while I was on vacation) to revert, fix, reapply etc.

eg. https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/1133
which was merged, then again mostly reverted.

For a minor fix, it's now become quite confusing and time consuming.

The original PR fixed:

1. Always reject with an Error — this is how bugsnag gets it's stack trace.
  That fix is now already in develop.

2. Flattened the mixed pyramids of Promise and async functions so that it's easier to follow, test and debug.

---

It is newly rebased on develop.

I tested login / logout and session refresh on web and react-native iOS (same code as for Android)

Fixes #1134  - Fix unhandled rejection in getAccessToken