### PR TITLE
Conditionally activate bugsnag only if api key is in config

### DIFF
--- a/app/components/ErrorBoundry/globalErrorBoundry.js
+++ b/app/components/ErrorBoundry/globalErrorBoundry.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { info } from '../../assets';
+import { context } from '../../config';
 import i18n from '../../locales/i18n.js';
 import bugsnag from '@bugsnag/js';
 import {
@@ -8,10 +9,13 @@ import {
   version as app_version
 } from '../../../package.json';
 
-const bugsnagClient = bugsnag({
-  apiKey: '6f2971a9b077662912f61ae602716afd',
-  appVersion: app_version
-});
+let bugsnagClient;
+if (context.bugsnagApiKey) {
+  bugsnagClient = bugsnag({
+    apiKey: context.bugsnagApiKey,
+    appVersion: app_version
+  });
+}
 
 export default class GlobalErrorBoundary extends React.Component {
   constructor(props) {
@@ -21,10 +25,13 @@ export default class GlobalErrorBoundary extends React.Component {
 
   componentDidCatch(error, info) {
     this.setState({ hasErrorOccurred: true });
-    console.log(error, info);
-    bugsnag.notify(error, function(report) {
-      report.metadata = { info: info };
-    });
+    console.error(error, info);
+
+    if (bugsnagClient) {
+      bugsnag.notify(error, function(report) {
+        report.metadata = { info: info };
+      });
+    }
   }
 
   render() {

--- a/app/components/ErrorBoundry/globalErrorBoundry.native.js
+++ b/app/components/ErrorBoundry/globalErrorBoundry.native.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, View, ScrollView, SafeAreaView } from 'react-native';
+import { context } from '../../config';
 import styles from '../../styles/edit_profile.native';
 import i18n from '../../locales/i18n.js';
 import { Client, Configuration } from 'bugsnag-react-native';
@@ -9,10 +10,13 @@ import {
   version as app_version
 } from '../../../package.json';
 
-const configuration = new Configuration();
-configuration.apiKey = '6f2971a9b077662912f61ae602716afd';
-configuration.codeBundleId = app_version;
-bugsnag = new Client(configuration);
+let bugsnag;
+if (context.bugsnagApiKey) {
+  const configuration = new Configuration();
+  configuration.apiKey = context.bugsnagApiKey;
+  configuration.codeBundleId = app_version;
+  bugsnag = new Client(configuration);
+}
 
 export default class GlobalErrorBoundary extends React.Component {
   constructor(props) {
@@ -22,9 +26,11 @@ export default class GlobalErrorBoundary extends React.Component {
 
   componentDidCatch(error, info) {
     this.setState({ hasErrorOccurred: true, error, info });
-    bugsnag.notify(error, function(report) {
-      report.metadata = { info: info };
-    });
+    if (bugsnag) {
+      bugsnag.notify(error, function(report) {
+        report.metadata = { info: info };
+      });
+    }
   }
 
   render() {

--- a/app/config/index.js.dist
+++ b/app/config/index.js.dist
@@ -17,5 +17,6 @@ export const context = {
   base: '',  // API base url. Debug mode off: "" on: "/app_dev.php" (requires login)
   debug: true, // local console debugging switch
   currency: 'USD',
-  mapIds: { inventory: 'dee6acf9de774fe6878813f707b4ab88'}
+  mapIds: { inventory: 'dee6acf9de774fe6878813f707b4ab88'},
+  bugsnagApiKey: ''
 };

--- a/web/config/webpack.prod_server.config.js
+++ b/web/config/webpack.prod_server.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const WebpackCleanupPlugin = require('webpack-cleanup-plugin');
+const context = require('../../app/config/index.js');
 const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const {
@@ -37,11 +38,11 @@ module.exports = webpackMerge(commonConfig, {
   devtool: 'source-map',
   plugins: [
     new BugsnagBuildReporterPlugin({
-      apiKey: '6f2971a9b077662912f61ae602716afd',
+      apiKey: context.bugsnagApiKey,
       appVersion: pkg.version
     }),
     new BugsnagSourceMapUploaderPlugin({
-      apiKey: '6f2971a9b077662912f61ae602716afd',
+      apiKey: context.bugsnagApiKey,
       appVersion: pkg.version,
       overwrite: true,
       publicPath: '*'


### PR DESCRIPTION
This gets the bugsnag api key from `config/index.js` and activates bugsnag reporting only if it's set.

Avoids all developers sending bugsnag errors by default from their local machines.

This is a simple alternative to the problematic attempt to use 12 factor env vars: https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/1199 ( which seemed like a good idea at the time ).