### PR TITLE
fix: getTitle Cannot read property 'titleParam' of undefined

### DIFF
--- a/app/components/Navigators/AppDrawerNavigator.js
+++ b/app/components/Navigators/AppDrawerNavigator.js
@@ -241,16 +241,13 @@ export const getAppNavigator = function(isLoggedIn, userProfile) {
           navigation.state.routes &&
           navigation.state.routes.length > 0
         ) {
-          if (navigation.state.routes[index].routeName === '/home') {
+          const route = navigation.state.routes[index];
+          if (route.routeName === '/home') {
             title = userProfile.fullname;
           } else {
-            title = i18n.t(
-              headerLabels[navigation.state.routes[index].routeName]
-            );
-            if (navigation.state.routes[index].hasOwnProperty('params')) {
-              const childTitle =
-                navigation.state.routes[index].params.titleParam;
-
+            title = i18n.t(headerLabels[route.routeName]);
+            if (route.params) {
+              const childTitle = route.params.titleParam;
               if (childTitle) {
                 title = childTitle;
               }


### PR DESCRIPTION
This error is logged for many pages. 

Due to the `try ... catch` the app was still running, but this fixes the underlying issue.

```
TypeError: Cannot read property 'titleParam' of undefined
    at getTitle (AppDrawerNavigator.js:252)
    at navigationOptions (AppDrawerNavigator.js:324)
    at applyConfig (createConfigGetter.js:10)
    at Object.getScreenOptions (createConfigGetter.js:47)
    at createNavigator.js:42
    at Array.forEach (<anonymous>)
    at getDerivedStateFromProps (createNavigator.js:27)
    at applyDerivedStateFromProps (ReactNativeRenderer-dev.js:6896)
    at updateClassInstance (ReactNativeRenderer-dev.js:7837)
    at updateClassComponent (ReactNativeRenderer-dev.js:11500)
```