### PR TITLE
added CircleCI config to build branches without backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,29 @@ jobs:
           name: Install npm
           command: npm install
       - run:
-          name: Build Application
+          name: Setup local configuration
+          command: cp app/config/index.js.dist app/config/index.js
+      - run:
+          name: Build web client
+          command: npm run build:server
+      - run:
+          name: Build Android app
           command: |
-            cp app/config/index.js.dist app/config/index.js
-            npm run build:server
+            react-native bundle \
+                --platform android \
+                --dev false \
+                --entry-file index.js \
+                --bundle-output android-release.bundle \
+                --sourcemap-output android-release.bundle.map
+      - run:
+          name: Build iOS app
+          command: |
+            react-native bundle \
+                --platform ios \
+                --dev false \
+                --entry-file index.js \
+                --bundle-output ios-release.bundle \
+                --sourcemap-output ios-release.bundle.map
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,9 @@ jobs:
       - run:
           name: Update npm
           command: 'sudo npm install -g npm@latest'
+      - run:
+          name: Install react-native CLI
+          command: 'sudo npm install -g react-native-cli'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,30 @@ jobs:
             source $ENV_VARS
             ssh $HOST "cd $WD_SYMFONY; sh .circleci/integrate-app.sh $CIRCLE_BRANCH"
 
+  build_gitflow:
+    docker:
+      - image: circleci/node:10.11-jessie
+    working_directory: ~/ttc-app
+    steps:
+      - checkout
+      - run:
+          name: Update npm
+          command: 'sudo npm install -g npm@latest'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Install npm
+          command: npm install
+      - run:
+          name: Build Application
+          command: |
+            cp app/config/index.js.dist app/config/index.js
+            npm run build:server
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+
 workflows:
   version: 2
   tagged-build:
@@ -90,3 +114,11 @@ workflows:
                 - test
                 - staging
                 - devel
+      - build_gitflow:
+          filters:
+            branches:
+              only:
+                - develop
+                - /^feature\/.*/
+                - /^hotfix\/.*/
+                - /^release\/.*/


### PR DESCRIPTION
I added a configuration for building all GitFlow branches (for code validation) which do not yet have a backend. Both the source for the web client as the bundles for the iOS and Android are build to detect errors.

These builds do not use any resources of our production server, while the protected branches `master`, `staging`, `test` and `devel` are currently directly being build on our production server and therefore **use up CPU power from the live system**.