### PR TITLE
Fix: getLocale() - initialize on demand

### DIFF
--- a/app/actions/getLocale.js
+++ b/app/actions/getLocale.js
@@ -11,6 +11,9 @@ export function initLocale() {
 
 export function getLocale() {
   // console.log('getLocale', cache.locale);
+  if (!cache.locale) {
+    initLocale();
+  }
   return cache.locale;
 }
 


### PR DESCRIPTION
PR https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/1208
assumed that locale could be initialized on app startup,
but i18n.js calls getLocale() before that. Regardless of what calls first,
this initializes locale if needed.