### PR TITLE
Fix #1210 and more issues by removing one level of "response"

### DIFF
--- a/app/actions/EditMyTree.js
+++ b/app/actions/EditMyTree.js
@@ -36,11 +36,11 @@ export function editTree(plantContribution, plantId, navigation) {
         dispatch(setProgressModelState(false));
         updateRoute('app_userHome', navigation || dispatch);
       })
-      .catch(error => {
-        debug(error.response);
+      .catch(response => {
+        debug(response);
         dispatch(setProgressModelState(false));
         NotificationManager.error(
-          error.response.data.message,
+          response.data.message,
           i18n.t('label.error'),
           5000
         );
@@ -77,16 +77,16 @@ export function deleteContribution(plantContributionId) {
             5000
           );
         })
-        .catch(err => {
-          debug(err);
+        .catch(response => {
+          debug(response);
 
           NotificationManager.error(
-            error.response.data.message,
+            response.data.message,
             i18n.t('label.error'),
             5000
           );
 
-          reject(err);
+          reject(response);
         })
         .finally(data => {
           dispatch(setProgressModelState(false));

--- a/app/actions/challengeActions.js
+++ b/app/actions/challengeActions.js
@@ -31,12 +31,12 @@ export function challenge(challengeDetails) {
             5000
           );
         })
-        .catch(error => {
-          debug('error: ', error);
-          reject(error);
+        .catch(response => {
+          debug('error: ', response);
+          reject(response);
           dispatch(setProgressModelState(false));
           NotificationManager.error(
-            error.response.data.message,
+            response.data.message,
             i18n.t('label.error'),
             5000
           );

--- a/app/containers/Challenge/createChallenge.js
+++ b/app/containers/Challenge/createChallenge.js
@@ -43,10 +43,10 @@ class ChallengeContainer extends Component {
           challengeSuccess: true
         });
       })
-      .catch(err => {
-        console.log(err.response.data);
+      .catch(response => {
+        console.log(response.data);
         this.setState({
-          error: err.response.data.minTarget
+          error: response.data.minTarget
         });
       });
   }


### PR DESCRIPTION
Fix #1210 
Fix #1211 
Fix #1003

I think this is the same duplication of trying to access a `response` object as in https://github.com/Plant-for-the-Planet-org/treecounter-app/commit/968a9fcb54d61c0d2cdadfb3586c9ff90e0c3760 - is it?