### PR TITLE
fix: PledgeEvents import connect for updated react-redux 7

### DIFF
--- a/app/components/PledgeEvents/PledgeEvents.native.js
+++ b/app/components/PledgeEvents/PledgeEvents.native.js
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   Image
 } from 'react-native';
-import connect from 'react-redux/es/connect/connect';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '../../locales/i18n';
 import PledgeTabView from './PledgeTabView.native';
@@ -87,7 +87,7 @@ class PledgeEvents extends Component {
           this.props.pledges.pledgeEventImages &&
           this.props.pledges.pledgeEventImages.length > 0 ? (
             <ScrollView
-              horizontal={true}
+              horizontal
               showsHorizontalScrollIndicator={false}
               contentContainerStyle={styles.peSliderScrollView}
             >


### PR DESCRIPTION
PledgeEvents https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/1324 was merged after the redux update https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/1287

There was one import in #1324 that imported using the older API. This updates to the new import path 