### PR TITLE
Fix problem with async setState when changing currency

### DIFF
--- a/app/components/Currency/TreeCountCurrencySelector.js
+++ b/app/components/Currency/TreeCountCurrencySelector.js
@@ -58,7 +58,7 @@ class TreeCountCurrencySelector extends React.Component {
 
   updateStateAndParent(updates) {
     const newState = { ...this.state, ...updates };
-    this.setState(newState, function afterSetState() {
+    this.setState(newState, () => {
       this.props.onChange({
         currency: newState.selectedCurrency,
         amount: newState.selectedAmount,

--- a/app/components/Currency/TreeCountCurrencySelector.js
+++ b/app/components/Currency/TreeCountCurrencySelector.js
@@ -58,12 +58,12 @@ class TreeCountCurrencySelector extends React.Component {
 
   updateStateAndParent(updates) {
     const newState = { ...this.state, ...updates };
-    this.setState(newState);
-
-    this.props.onChange({
-      currency: newState.selectedCurrency,
-      amount: newState.selectedAmount,
-      treeCount: newState.selectedTreeCount
+    this.setState(newState, function afterSetState() {
+      this.props.onChange({
+        currency: newState.selectedCurrency,
+        amount: newState.selectedAmount,
+        treeCount: newState.selectedTreeCount
+      });
     });
   }
 

--- a/app/components/Currency/TreeCountCurrencySelector.native.js
+++ b/app/components/Currency/TreeCountCurrencySelector.native.js
@@ -66,12 +66,12 @@ class TreeCountCurrencySelector extends React.PureComponent {
 
   updateStateAndParent(updates) {
     const newState = { ...this.state, ...updates };
-    this.setState(newState);
-
-    this.props.onChange({
-      currency: newState.selectedCurrency,
-      amount: newState.selectedAmount,
-      treeCount: newState.selectedTreeCount
+    this.setState(newState, function afterSetState() {
+      this.props.onChange({
+        currency: newState.selectedCurrency,
+        amount: newState.selectedAmount,
+        treeCount: newState.selectedTreeCount
+      });
     });
   }
 

--- a/app/components/Currency/TreeCountCurrencySelector.native.js
+++ b/app/components/Currency/TreeCountCurrencySelector.native.js
@@ -66,7 +66,7 @@ class TreeCountCurrencySelector extends React.PureComponent {
 
   updateStateAndParent(updates) {
     const newState = { ...this.state, ...updates };
-    this.setState(newState, function afterSetState() {
+    this.setState(newState, () => {
       this.props.onChange({
         currency: newState.selectedCurrency,
         amount: newState.selectedAmount,


### PR DESCRIPTION
We have a problem with wrong donation amounts calculated from the native app:

![File](https://user-images.githubusercontent.com/1532418/64164285-393de880-ce43-11e9-940c-ad565b54a3da.jpg)

I found out that when the currency is changed in the `CurrencySelector` component the `TreeCountCurrencySelector` component calls the method `handleCurrencyChange` which uses `this.setState()` to change its internal state and at the same time announced the change to the component above (e.g. DonateTrees) which again changes its internal state and forces an update of all components contained.
Therefore within `TreeCountCurrencySelector` also the method `handleTreeCountChange` got called again changing the internal state and announcing it to the component above.

The problem is that `this.setState()` is async and therefore `this.state` is not updated at the time it god read for the second time and therefore old values are used with the second `this.setState()` call.

I tried to fix this now by waiting until `this.setState()` is finished until the change gets announced to the above component triggering any further updates.