### PR TITLE
differ between singular and plural form of number names

### DIFF
--- a/app/locales/de/commonlabels.json
+++ b/app/locales/de/commonlabels.json
@@ -23,10 +23,16 @@
   "plant_for_the_planet_app": "Plant-for-the-Planet App",
   "a_solution_for_climate_crisis": "Eine Lösung für die Klimakrise",
   "get_app_button_text": "LOS",
-  "Thousand": "Tausend",
-  "Million": "Million",
-  "Billion": "Milliarden",
-  "Trillion": "Billion",
-  "Quadrillion": "Billiarde",
-  "Quintillion": "Trillion"
+  "thousand_singular": "Tausend",
+  "thousand_plural": "Tausend",
+  "million_singular": "Million",
+  "million_plural": "Millionen",
+  "billion_singular": "Milliarde",
+  "billion_plural": "Milliarden",
+  "trillion_singular": "Billion",
+  "trillion_plural": "Billionen",
+  "quadrillion_singular": "Billiarde",
+  "quadrillion_plural": "Billiarden",
+  "quintillion_singular": "Trillion",
+  "quintillion_plural": "Trillionen"
 }

--- a/app/locales/en/commonlabels.json
+++ b/app/locales/en/commonlabels.json
@@ -23,10 +23,16 @@
   "plant_for_the_planet_app": "Plant-for-the-planet App",
   "a_solution_for_climate_crisis": "A solution for Climate Crisis",
   "get_app_button_text": "GET",
-  "Thousand": "Thousand",
-  "Million": "Million",
-  "Billion": "Billion",
-  "Trillion": "Trillion",
-  "Quadrillion": "Quadrillion",
-  "Quintillion": "Quintillion"
+  "thousand_singular": "Thousand",
+  "thousand_plural": "Thousand",
+  "million_singular": "Million",
+  "million_plural": "Million",
+  "billion_singular": "Billion",
+  "billion_plural": "Billion",
+  "trillion_singular": "Trillion",
+  "trillion_plural": "Trillion",
+  "quadrillion_singular": "Quadrillion",
+  "quadrillion_plural": "Quadrillion",
+  "quintillion_singular": "Quintillion",
+  "quintillion_plural": "Quintillion"
 }

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -65,31 +65,40 @@ export function convertNumber(n, d) {
   if (isNaN(n) || undefined) {
     return 0;
   }
-  let x = ('' + n).length;
-  if (x > 12) {
-    let p = Math.pow;
-    d = p(10, d);
-    x -= x % 3;
-    return (
-      delimitNumbers(Math.round(n * d / p(10, x)) / d) +
-      [
-        '',
-        ' ' + i18n.t('label.Thousand'),
-        ' ' + i18n.t('label.Million'),
-        ' ' + i18n.t('label.Billion'),
-        ' ' + i18n.t('label.Trillion'),
-        ' ' + i18n.t('label.Quadrillion'),
-        ' ' + i18n.t('label.Quintillion')
-      ][x / 3]
-    );
-  } else if (x > 9) {
-    return delimitNumbers(n / 1000000000) + ' ' + i18n.t('label.Billion');
-  } else if (x > 6) {
-    return delimitNumbers(n / 1000000) + ' ' + i18n.t('label.Million');
-    // TODO: think about using the label "thousend" - under 1 Mio it's uncommon to use it
-  } else if (x > 3) {
-    return delimitNumbers(n / 1000) + ' ' + i18n.t('label.Thousand');
-  } else {
-    return delimitNumbers(n);
-  }
+  let x = ('' + n).length - 1;
+  x -= x % 3;
+  let p = Math.pow;
+  d = p(10, d);
+  let rounded = Math.round(n * d / p(10, x)) / d;
+  let singular = rounded == 1 ? 1 : 0;
+  return (
+    delimitNumbers(rounded) +
+    [
+      '',
+      ' ' +
+        (singular
+          ? i18n.t('label.thousand_singular')
+          : i18n.t('label.thousand_plural')),
+      ' ' +
+        (singular
+          ? i18n.t('label.million_singular')
+          : i18n.t('label.million_plural')),
+      ' ' +
+        (singular
+          ? i18n.t('label.billion_singular')
+          : i18n.t('label.billion_plural')),
+      ' ' +
+        (singular
+          ? i18n.t('label.trillion_singular')
+          : i18n.t('label.trillion_plural')),
+      ' ' +
+        (singular
+          ? i18n.t('label.quadrillion_singular')
+          : i18n.t('label.quadrillion_plural')),
+      ' ' +
+        (singular
+          ? i18n.t('label.quintillion_singular')
+          : i18n.t('label.quintillion_plural'))
+    ][x / 3]
+  );
 }

--- a/web/stylesheet/_home_svg.scss
+++ b/web/stylesheet/_home_svg.scss
@@ -38,7 +38,7 @@
     }
     strong {
       @extend .pftp-text-basic;
-      font-size: 32.5px;
+      font-size: 28.5px;
       font-weight: 600;
       text-align: left;
       color: $headerTextColor;
@@ -47,7 +47,7 @@
       }
     }
     strong.small {
-      font-size: 26.5px;
+      font-size: 22.5px;
       @include for-phone-only {
         font-size: 15.5px;
       }


### PR DESCRIPTION
Fix #1346
- decreased font size for numbers as still breaks occur

For English the singular and plural form is identical while for German we use the singular form only for 1 and else the plural form (exception for thousand where we always use the singular form).