### PR TITLE
remove 200kb react-render-html module

### DIFF
--- a/app/components/AboutUs/LicenseInfo.json
+++ b/app/components/AboutUs/LicenseInfo.json
@@ -487,14 +487,6 @@
         "path": "/Users/norbertschuler/Development/PFTP/treecounter-app/node_modules/react-redux",
         "licenseFile": "/Users/norbertschuler/Development/PFTP/treecounter-app/node_modules/react-redux/LICENSE.md"
       },
-      "react-render-html@0.6.0": {
-        "licenses": "MIT",
-        "repository": "https://github.com/utatti/react-render-html",
-        "publisher": "Hyunje Jun",
-        "email": "me@noraesae.net",
-        "path": "/Users/norbertschuler/Development/PFTP/treecounter-app/node_modules/react-render-html",
-        "licenseFile": "/Users/norbertschuler/Development/PFTP/treecounter-app/node_modules/react-render-html/LICENSE"
-      },
       "react-router-dom@4.3.1": {
         "licenses": "MIT",
         "repository": "https://github.com/ReactTraining/react-router",

--- a/app/components/FAQ/index.js
+++ b/app/components/FAQ/index.js
@@ -6,7 +6,6 @@ import {
   AccordionItemTitle,
   AccordionItemBody
 } from 'react-accessible-accordion';
-import renderHTML from 'react-render-html';
 import LoadingIndicator from '../../components/Common/LoadingIndicator';
 import TextHeading from '../../components/Common/Heading/TextHeading';
 import DescriptionHeading from '../../components/Common/Heading/DescriptionHeading';
@@ -24,7 +23,11 @@ export default class FAQ extends Component {
             <div className="accordion__arrow" role="presentation" />
           </div>
         </AccordionItemTitle>
-        <AccordionItemBody>{renderHTML(faq.answer)}</AccordionItemBody>
+        <AccordionItemBody>
+          <div dangerouslySetInnerHTML={{
+            __html: faq.answer
+          }} />
+        </AccordionItemBody>
       </AccordionItem>
     ));
   }

--- a/app/components/Header/Notification.js
+++ b/app/components/Header/Notification.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import renderHTML from 'react-render-html';
 import { getImageUrl } from '../../actions/apiRouting';
 import { SignupJustMe } from '../../assets';
 import i18n from '../../locales/i18n';
@@ -19,9 +18,9 @@ export default class Notification extends Component {
                   : SignupJustMe
               }
             />
-            <div className="item-html__wrapper">
-              {renderHTML(notification.message)}
-            </div>
+            <div className="item-html__wrapper" dangerouslySetInnerHTML={{
+              __html: notification.message
+            }} />
           </div>
         </li>
         <hr className="divider__light" />

--- a/app/components/Imprint/index.js
+++ b/app/components/Imprint/index.js
@@ -6,7 +6,6 @@ import {
   AccordionItemTitle,
   AccordionItemBody
 } from 'react-accessible-accordion';
-import renderHTML from 'react-render-html';
 import LoadingIndicator from '../../components/Common/LoadingIndicator';
 import TextHeading from '../../components/Common/Heading/TextHeading';
 import DescriptionHeading from '../../components/Common/Heading/DescriptionHeading';
@@ -21,7 +20,11 @@ export default class Imprint extends Component {
         <AccordionItemTitle>
           <div className="u-position-relative">{imprint.title}</div>
         </AccordionItemTitle>
-        <AccordionItemBody>{renderHTML(imprint.description)}</AccordionItemBody>
+        <AccordionItemBody>
+          <div dangerouslySetInnerHTML={{
+            __html: imprint.description
+          }} />
+        </AccordionItemBody>
       </AccordionItem>
     ));
   }

--- a/app/components/Privacy/index.js
+++ b/app/components/Privacy/index.js
@@ -6,7 +6,6 @@ import {
   AccordionItemTitle,
   AccordionItemBody
 } from 'react-accessible-accordion';
-import renderHTML from 'react-render-html';
 import LoadingIndicator from '../../components/Common/LoadingIndicator';
 import TextHeading from '../../components/Common/Heading/TextHeading';
 import DescriptionHeading from '../../components/Common/Heading/DescriptionHeading';
@@ -21,7 +20,11 @@ export default class Privacy extends Component {
         <AccordionItemTitle>
           <div className="u-position-relative">{privacy.heading}</div>
         </AccordionItemTitle>
-        <AccordionItemBody>{renderHTML(privacy.description)}</AccordionItemBody>
+        <AccordionItemBody>
+          <div dangerouslySetInnerHTML={{
+            __html: privacy.description
+          }} />
+        </AccordionItemBody>
       </AccordionItem>
     ));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16696,25 +16696,6 @@
         "react-is": "^16.9.0"
       }
     },
-    "react-render-html": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-render-html/-/react-render-html-0.6.0.tgz",
-      "integrity": "sha512-F9Xn8Iy2oJvepMdDrN+XUPOwqv3ni856ikuvu/dyJ2guozN01vF0C55Ja+CQfnziQNlLevSVXzuQKYa/mhyjAQ==",
-      "requires": {
-        "parse5": "^3.0.2",
-        "react-attr-converter": "^0.3.1"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
-      }
-    },
     "react-router": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react-navigation-redux-helpers": "^1.1.2",
     "react-notifications": "^1.4.3",
     "react-redux": "^7.1.0",
-    "react-render-html": "^0.6.0",
     "react-router-dom": "^4.2.2",
     "react-share": "^2.4.0",
     "react-slick": "^0.23.1",


### PR DESCRIPTION
In order to try reducing the size of our bundle.js (until we are able to split it up) I checked what modules might not be needed and found that `react-render-html` could be replace with some more simple solution.
I also checked if now the website is more vulnerable against XSS attacks as the notifications (FAQ, privacy policy and imprint should be save as only containing content controlled by us) may contain user generated content, but found out it was already vulnerable before as the user profile name did not get escaped in the backend before put into the notification HTML messages. So this patch doesn't make it worse. I created a new issue #1398 for that.

Use `npm run analyze` to compare the bundle size before and after this patch.