### PR TITLE
Feature: Refactor progress modal

### DIFF
--- a/app/components/App/TreeCounter.js
+++ b/app/components/App/TreeCounter.js
@@ -329,8 +329,7 @@ class TreeCounter extends Component {
       <div className="app">
         <BrowserRouter history={history}>
           <div className="app-container">
-            <ProgressModal isOpen={this.props.progressModel} />
-
+            <ProgressModal />
             <HeaderContainer />
             <Route component={SideMenuContainer} />
             {this._appRoutes}
@@ -348,8 +347,7 @@ class TreeCounter extends Component {
 }
 
 const mapStateToProps = state => ({
-  userProfile: currentUserProfileSelector(state),
-  progressModel: state.modelDialogState.progressModel
+  userProfile: currentUserProfileSelector(state)
 });
 
 const mapDispatchToProps = dispatch => {
@@ -372,6 +370,5 @@ TreeCounter.propTypes = {
   NotificationAction: PropTypes.func,
   loadTpos: PropTypes.func,
   dispatch: PropTypes.func,
-  progressModel: PropTypes.bool,
   fetchpledgeEventsAction: PropTypes.func
 };

--- a/app/components/Common/ModalDialog/ProgressModal.js
+++ b/app/components/Common/ModalDialog/ProgressModal.js
@@ -1,26 +1,34 @@
-import Modal from 'react-modal';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import Modal from 'react-modal';
+import { useSelector } from 'react-redux';
+
+import { getProgressModelState } from '../../../reducers/modelDialogReducer';
 import LoadingIndicator from '../LoadingIndicator';
 
-const ProgressModal = ({ isOpen, onRequestClose }) => (
-  <Modal
-    isOpen={isOpen}
-    className="progressModal"
-    overlayClassName="Overlay"
-    portalClassName="ModalPortal"
-    ariaHideApp={false}
-    onRequestClose={onRequestClose}
-    shouldFocusAfterRender
-  >
-    <div>
-      <LoadingIndicator />
-    </div>
-  </Modal>
-);
+const ProgressModal = ({ onRequestClose }) => {
+  // This component will re-render anytime progressModalState is updated in redux:
+  //   dispatch(setProgressModelState(true));
+  const isOpen = useSelector(getProgressModelState);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      className="progressModal"
+      overlayClassName="Overlay"
+      portalClassName="ModalPortal"
+      ariaHideApp={false}
+      onRequestClose={onRequestClose}
+      shouldFocusAfterRender
+    >
+      <div>
+        <LoadingIndicator />
+      </div>
+    </Modal>
+  );
+};
 
 ProgressModal.propTypes = {
-  isOpen: PropTypes.bool,
   onRequestClose: PropTypes.func
 };
 

--- a/app/components/Common/ModalDialog/ProgressModal.native.js
+++ b/app/components/Common/ModalDialog/ProgressModal.native.js
@@ -1,34 +1,39 @@
-import React, { Component } from 'react';
-import { View, Modal, Alert } from 'react-native';
+import React from 'react';
+import { Alert, Modal, View } from 'react-native';
+import { useSelector } from 'react-redux';
 
+import { getProgressModelState } from '../../../reducers/modelDialogReducer';
 import LoadingIndicator from '../LoadingIndicator';
 
-export default class ProgressModal extends Component {
-  render = () => {
-    const backgroundColor = 'rgba(255,255,255,0.5)';
-    return (
-      <Modal
-        animationType={'slide'}
-        transparent
-        visible={this.props.modalVisible}
-        elevation="10"
-        onRequestClose={() => {
-          Alert.alert('Loading cancelled in between');
+const ProgressModal = () => {
+  // This component will re-render anytime progressModalState is updated in redux
+  const isOpen = useSelector(getProgressModelState);
+  const backgroundColor = 'rgba(255,255,255,0.5)';
+
+  return (
+    <Modal
+      animationType={'slide'}
+      transparent
+      visible={isOpen}
+      elevation="10"
+      onRequestClose={() => {
+        Alert.alert('Loading cancelled in between');
+      }}
+    >
+      <View
+        style={{
+          flex: 1,
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          elevation: 10,
+          backgroundColor
         }}
       >
-        <View
-          style={{
-            flex: 1,
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            elevation: 10,
-            backgroundColor: backgroundColor
-          }}
-        >
-          <LoadingIndicator />
-        </View>
-      </Modal>
-    );
-  };
-}
+        <LoadingIndicator />
+      </View>
+    </Modal>
+  );
+};
+
+export default ProgressModal;

--- a/app/containers/Navigators/AppDrawerNavigatorContainer.js
+++ b/app/containers/Navigators/AppDrawerNavigatorContainer.js
@@ -46,22 +46,20 @@ class AppDrawerNavigatorContainer extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     //If there is no change in the user login state then don't re-render the component
     if (
-      this.props.progressModel === nextProps.progressModel &&
-      ((nextState.loading === this.state.loading &&
+      (nextState.loading === this.state.loading &&
         nextState.isLoggedIn === this.state.isLoggedIn &&
         (!nextProps.userProfile && !this.props.userProfile)) ||
-        (nextProps.userProfile &&
-          this.props.userProfile &&
-          nextProps.userProfile.id === this.props.userProfile.id))
+      (nextProps.userProfile &&
+        this.props.userProfile &&
+        nextProps.userProfile.id === this.props.userProfile.id)
     ) {
       return false;
     }
-    if (this.props.progressModel === nextProps.progressModel) {
-      this._AppNavigator = getAppNavigator(
-        nextState.isLoggedIn,
-        nextProps.userProfile
-      );
-    }
+    // shouldComponentUpdate should be pure !!
+    this._AppNavigator = getAppNavigator(
+      nextState.isLoggedIn,
+      nextProps.userProfile
+    );
     return true;
   }
   async componentWillMount() {
@@ -99,7 +97,7 @@ class AppDrawerNavigatorContainer extends Component {
       return (
         <View style={{ flex: 1 }}>
           <this._AppNavigator />
-          {this.props.progressModel ? <ProgressModal modalVisible /> : null}
+          <ProgressModal />
         </View>
       );
     }
@@ -109,7 +107,6 @@ class AppDrawerNavigatorContainer extends Component {
   static propTypes = {
     dispatch: PropTypes.func,
     loadUserProfile: PropTypes.func,
-    progressModel: PropTypes.bool,
     fetchpledgeEventsAction: PropTypes.func
   };
 }
@@ -117,8 +114,7 @@ class AppDrawerNavigatorContainer extends Component {
 const mapStateToProps = state => {
   return {
     appDrawer: state.appDrawer,
-    userProfile: currentUserProfileSelector(state),
-    progressModel: state.modelDialogState.progressModel
+    userProfile: currentUserProfileSelector(state)
   };
 };
 

--- a/app/reducers/modelDialogReducer.js
+++ b/app/reducers/modelDialogReducer.js
@@ -1,7 +1,8 @@
 import { createAction, handleActions } from 'redux-actions';
 
 export const setProgressModelState = createAction('PROGRESS_MODEL_STATE');
-export const getProgressModelState = state => state.progressModel;
+export const getProgressModelState = state =>
+  state.modelDialogState.progressModel;
 
 export const initialState = {
   progressModel: false,


### PR DESCRIPTION
This uses the new redux hooks to connect ProgressModal directly to redux state changes. 

Now the entire top level app doesn't need to re-render every time 
```js
dispatch(setProgressModelState(true))
```
is called.

The modal shows/hides by itself.
