### PR TITLE
readjusted position and shortened for smaller devices

### DIFF
--- a/app/components/Currency/CurrencySelector.native.js
+++ b/app/components/Currency/CurrencySelector.native.js
@@ -23,34 +23,23 @@ const CurrencySelector = ({ currencies, selectedCurrency, onChange }) => {
 
   return (
     <Dropdown
-      containerStyle={[
-        {
-          width: '100%',
-          marginLeft: 10,
-          marginBottom: 10,
-          paddingRight: 10,
-          elevation: 2
-        }
-      ]}
+      containerStyle={{
+        width: '100%',
+        marginLeft: 10,
+        marginBottom: 10,
+        paddingRight: 10,
+        elevation: 2
+      }}
       pickerStyle={{
         position: 'absolute',
-        maxHeight: Dimensions.get('window').height - 150,
-        marginTop: 'auto',
-        top:
-          Dimensions.get('window').height / 2 >=
-          currenciesDropdownFormat.length * 18
-            ? Dimensions.get('window').height / 2 -
-              currenciesDropdownFormat.length * 18
-            : 75,
-        alignSelf: 'center',
-        flex: 1,
+        maxHeight: Dimensions.get('window').height
+          ? Dimensions.get('window').height - 160
+          : 400,
+        top: 160,
         zIndex: 60
       }}
-      itemCount={20}
-      dropdownOffset={{
-        top: 10,
-        left: 0
-      }}
+      itemCount={10}
+      dropdownPosition={1}
       animationDuration={0}
       itemTextStyle={{
         fontSize: 13,


### PR DESCRIPTION
Fix #1364 

Now the chooser shows only a smaller number of items, but it keeps it position in the middle of the screen and also show selected items for currencies at the bottom of the list.