### PR TITLE
Prevent web client crash in payment process and show an error instead

### DIFF
--- a/app/components/Payment/PaymentSelector.js
+++ b/app/components/Payment/PaymentSelector.js
@@ -69,32 +69,41 @@ class PaymentSelector extends Component {
     } else {
       const donationId = this.props.donationId
         ? this.props.donationId
-        : this.props.paymentStatus.contribution[0].id;
-      setProgressModelState(true);
-      this.props
-        .handlePay(
-          donationId,
-          {
-            gateway,
-            account: accountName,
-            source: { ...data }
-          },
-          this.props.currentUserProfile
-        )
-        .then(response => {
-          if (response.data.status == 'failed') {
-            this.props.paymentFailed({
-              status: false,
-              message: response.data.message || 'error'
-            });
-          } else {
-            this.props.finalizeDonation(
-              donationId,
-              this.props.currentUserProfile
-            );
-          }
-          setProgressModelState(false);
+        : this.props.paymentStatus
+          ? this.props.paymentStatus.contribution[0].id
+          : undefined;
+      if (donationId) {
+        setProgressModelState(true);
+        this.props
+          .handlePay(
+            donationId,
+            {
+              gateway,
+              account: accountName,
+              source: { ...data }
+            },
+            this.props.currentUserProfile
+          )
+          .then(response => {
+            if (response.data.status == 'failed') {
+              this.props.paymentFailed({
+                status: false,
+                message: response.data.message || 'error'
+              });
+            } else {
+              this.props.finalizeDonation(
+                donationId,
+                this.props.currentUserProfile
+              );
+            }
+            setProgressModelState(false);
+          });
+      } else {
+        this.props.paymentFailed({
+          status: false,
+          message: 'donation id missing error'
         });
+      }
     }
   }
 

--- a/app/components/StripePayment/CheckoutForm.js
+++ b/app/components/StripePayment/CheckoutForm.js
@@ -96,41 +96,50 @@ class CheckoutForm extends React.Component {
     if (paymentMethodId !== undefined || paymentMethodId != 0) {
       const donationId = this.props.donationId
         ? this.props.donationId
-        : this.props.paymentStatus.contribution[0].id;
-      let requestData = {
-        account: this.props.accountName,
-        gateway: this.props.gateway,
-        source: {
-          id: paymentMethodId,
-          object: 'payment_method'
-        }
-      };
-      this.props
-        .handlePay(donationId, requestData, this.props.currentUserProfile)
-        .then(response => {
-          this.props.setProgressModelState(false);
-          if (response.data.status == 'failed') {
-            this.props.paymentFailed({
-              status: false,
-              message: response.data.message || 'error'
-            });
-          } else {
-            if (response.data.status == 'action_required') {
-              this.handle3DSecure(
-                response.data.response.payment_intent_client_secret,
-                window.Stripe(this.props.stripePublishableKey, {
-                  stripeAccount: response.data.response.account
-                }),
-                donationId
-              );
-            } else {
-              this.props.finalizeDonation(
-                donationId,
-                this.props.currentUserProfile
-              );
-            }
+        : this.props.paymentStatus
+          ? this.props.paymentStatus.contribution[0].id
+          : undefined;
+      if (donationId) {
+        let requestData = {
+          account: this.props.accountName,
+          gateway: this.props.gateway,
+          source: {
+            id: paymentMethodId,
+            object: 'payment_method'
           }
+        };
+        this.props
+          .handlePay(donationId, requestData, this.props.currentUserProfile)
+          .then(response => {
+            this.props.setProgressModelState(false);
+            if (response.data.status == 'failed') {
+              this.props.paymentFailed({
+                status: false,
+                message: response.data.message || 'error'
+              });
+            } else {
+              if (response.data.status == 'action_required') {
+                this.handle3DSecure(
+                  response.data.response.payment_intent_client_secret,
+                  window.Stripe(this.props.stripePublishableKey, {
+                    stripeAccount: response.data.response.account
+                  }),
+                  donationId
+                );
+              } else {
+                this.props.finalizeDonation(
+                  donationId,
+                  this.props.currentUserProfile
+                );
+              }
+            }
+          });
+      } else {
+        this.props.paymentFailed({
+          status: false,
+          message: 'donation id missing error'
         });
+      }
     }
   };
 


### PR DESCRIPTION
THIS IS NOT A FIX - IT'S JUST A BETTER INDICATOR OF WHAT MIGHT BE THE PROBLEM!

Fix #1413 
Fix #1439

This is just a draft as it does not really fix the error but just prevents the crash and shows an error instead. 

You can reproduce the error by donating and entering a company address instead of your private address. Then there is neither a `props.donationId` nor a `this.props.paymentStatus` defined. But I have not yet figured out why or where it got lost. Compare the descriptions in the issue #1413 for more.