### PR TITLE
override the image size of loading indicator for explore

### DIFF
--- a/app/components/Leaderboard/index.js
+++ b/app/components/Leaderboard/index.js
@@ -66,7 +66,11 @@ export default class Leaderboard extends Component {
   };
 
   getTableView = hasSubSection => {
-    let listItemsUI = <LoadingIndicator />;
+    let listItemsUI = (
+      <div className="imageContainer">
+        <LoadingIndicator />
+      </div>
+    );
     const { categoryInfo, sectionInfo, queryResultSelfData } = this.props;
     if (this.props.queryResult)
       listItemsUI = (

--- a/web/stylesheet/leaderboard/_explore_leaderboard.scss
+++ b/web/stylesheet/leaderboard/_explore_leaderboard.scss
@@ -115,6 +115,14 @@
       margin-top: 8px;
       box-sizing: border-box;
       overflow-x: hidden;
+
+      .imageContainer {
+        img {
+          height: auto;
+          width: auto;
+        }
+      }
+
       .leaderboard-table {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
... to make it the same size as always.

Before the loading indicator was shown as a 25x25 pixel image as this was inherited from the pftp-tabs style. Now it it shown again in full size when switching between the different explore options.

Before:
<img width="726" alt="Bildschirmfoto 2019-09-24 um 09 46 19" src="https://user-images.githubusercontent.com/1532418/65491911-497c3d00-deb0-11e9-856c-2d07457760e4.png">

After:
<img width="726" alt="Bildschirmfoto 2019-09-24 um 09 45 16" src="https://user-images.githubusercontent.com/1532418/65491906-44b78900-deb0-11e9-8d21-769ffda006d8.png">

(It's just dark as I had to stop code execution in the browser to make the screenshots.)