### PR TITLE
Next button stuck issue fix where the trecounter id is not there

### DIFF
--- a/app/components/GiftTrees/index.js
+++ b/app/components/GiftTrees/index.js
@@ -289,7 +289,9 @@ export default class GiftTrees extends Component {
     this.setState({
       form: {
         ...this.state.form,
-        directGift: { treecounter: event.suggestion.treecounterId }
+        directGift: {
+          treecounter: event.suggestion.treecounterId || event.suggestion.id
+        }
       },
       giftTreecounterName: event.suggestion.name
     });


### PR DESCRIPTION
From #1120 with a users message https://github.com/Plant-for-the-Planet-org/treecounter-app/issues/1120#issuecomment-534967409