### PR TITLE
Fix crash on gift tree donation crash

### DIFF
--- a/app/components/GiftTrees/index.js
+++ b/app/components/GiftTrees/index.js
@@ -541,6 +541,11 @@ export default class GiftTrees extends Component {
                   }
                   amount={this.state.selectedAmount}
                   currency={this.state.selectedCurrency}
+                  paymentDetails={{
+                    amount: this.state.selectedAmount,
+                    currency: this.state.selectedCurrency,
+                    treeCount: this.state.selectedTreeCount
+                  }}
                   expandedOption={this.state.expandedOption}
                   handleExpandedClicked={this.handleExpandedClicked}
                   context={{


### PR DESCRIPTION
@sagararyal Reported an issue about gifttree donation crash
![Screenshot_20190929-103416_Chrome](https://user-images.githubusercontent.com/2967789/65833693-b3ec0d80-e2f4-11e9-966f-d7f8630bdc04.jpg)

Fixed by simple params missing