### PR TITLE
Fix #1477 showing blank screen if refreshing token fails

### DIFF
--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -11,9 +11,15 @@ export const getAccessToken = async () => {
   if (token) {
     // This may throw an Error if localStorage is broken
     // or POST requests timeout
-    const newToken = await refreshTokenIfExpired();
-    if (newToken) {
-      return newToken;
+    try {
+      const newToken = await refreshTokenIfExpired();
+      if (newToken) {
+        return newToken;
+      }
+    } catch (error) {
+      // 400
+      console.log(`Failed to refresh token: ${error}`);
+      return;
     }
   }
   return token;
@@ -42,21 +48,16 @@ const getExpirationTimeStamp = token => {
 const refreshTokenIfExpired = async () => {
   if (await tokenIsExpired()) {
     const prev_refresh_token = await fetchItem('refresh_token');
-    let response;
-    try {
-      response = await postRequest('gesdinet_jwt_refresh_token', {
-        refresh_token: prev_refresh_token
-      });
-    } catch (error) {
-      // 400
-      console.log(`Failed to refresh token: ${error}`);
-      return;
-    }
+    let response = await postRequest('gesdinet_jwt_refresh_token', {
+      refresh_token: prev_refresh_token
+    });
 
     const newToken = response.data.token;
     const refreshToken = response.data.refresh_token;
     updateJWT(newToken, refreshToken);
     return newToken;
+  } else {
+    return;
   }
 };
 


### PR DESCRIPTION
Until now getAccessToken returned the old token if the refreshing process for the expired token failed. I changed the code in order to return null if refreshing the token didn't work, so the page is not shown as blank but the user has a chance to login again.

Fix #1477 

You can test the different szenarios but modifying the local value of `token`, `token_expires` and `refresh_token` in the local browser storage, e.g. setting `refresh_token` and `token_expires` to 0 in order to check the case where this problems occurred.