### PR TITLE
build 'devel' tag & update server repositories for Dashboard again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@
 #
 version: 2
 jobs:
+
+  # build the app in the cloud and deploy it onto the dedicated backends
   build:
     docker:
       - image: circleci/node:10.11-jessie
@@ -23,9 +25,14 @@ jobs:
             then
               echo 'export WD_SYMFONY="$PROJ_DIR/ttc2018_prod"' >>  $ENV_VARS
               echo 'export SERVER_URL="www.trilliontreecampaign.org"' >>  $ENV_VARS
-            else
+            elif [[ "${CIRCLE_BRANCH}" == "staging" ]] || [[ "${CIRCLE_BRANCH}" == "test" ]]
+            then
               echo 'export WD_SYMFONY="$PROJ_DIR/ttc2018_${CIRCLE_BRANCH}"' >>  $ENV_VARS
               echo 'export SERVER_URL="${CIRCLE_BRANCH}.trilliontreecampaign.org"' >>  $ENV_VARS
+            else
+              # 'devel' tagged version
+              echo 'export WD_SYMFONY="$PROJ_DIR/ttc2018_devel"' >>  $ENV_VARS
+              echo 'export SERVER_URL="devel.trilliontreecampaign.org"' >>  $ENV_VARS
             fi
             cat $ENV_VARS
       # ID_RSA has been set up in project settings as base64 encoded content of 'id_rsa' file
@@ -72,6 +79,89 @@ jobs:
           paths:
             - node_modules
 
+  # only update the repository on the server to support our Dashboard
+  build_server_repository:
+    docker:
+      - image: alpine
+
+    environment:
+      HOST: ssh-840600-pftp2014@jetzt-die-welt-retten.de
+      PROJ_DIR: /kunden/188089_20457/pftp2014/source
+      ENV_VARS: ./env_vars.sh
+
+    working_directory: ~/ttc-app
+
+    steps:
+      - run: echo "$CIRCLE_BRANCH"
+      - run:
+          name: Setting Environment Variables
+          command: |
+            > $ENV_VARS
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]
+            then
+              echo 'export WD_REACT="$PROJ_DIR/ttc-app_prod"' >>  $ENV_VARS
+              echo 'export SERVER_URL="www.trilliontreecampaign.org"' >>  $ENV_VARS
+            elif [[ "${CIRCLE_BRANCH}" == "staging" ]] || [[ "${CIRCLE_BRANCH}" == "test" ]]
+            then
+              echo 'export WD_REACT="$PROJ_DIR/ttc-app_${CIRCLE_BRANCH}"' >>  $ENV_VARS
+              echo 'export SERVER_URL="${CIRCLE_BRANCH}.trilliontreecampaign.org"' >>  $ENV_VARS
+            else
+              # 'devel' tagged version
+              echo 'export WD_REACT="$PROJ_DIR/ttc-app_devel"' >>  $ENV_VARS
+              echo 'export SERVER_URL="devel.trilliontreecampaign.org"' >>  $ENV_VARS
+            fi
+            cat $ENV_VARS
+
+      # add SSH support
+      - run:
+          name: Install packages
+          command: |
+            apk update && apk add openssh
+      # ID_RSA has been set up in project settings as base64 encoded content of 'id_rsa' file
+      # https://circleci.com/gh/Plant-for-the-Planet-org/treecounter-platform/edit#env-vars
+      - run:
+          name: Setup SSH to Domain Factory
+          command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan jetzt-die-welt-retten.de 2>/dev/null >> ~/.ssh/known_hosts
+            (umask 077; touch ~/.ssh/id_rsa; chmod 0600 ~/.ssh/id_rsa)
+            echo $ID_RSA | base64 -d > ~/.ssh/id_rsa
+      - run:
+          name: Checkout web client
+          command: |
+            source $ENV_VARS
+            echo $WD_REACT
+            ssh $HOST "cd $WD_REACT; git fetch origin --prune && git fetch origin --tags"
+            if [[ "${CIRCLE_BRANCH}" ]]
+            then
+              ssh $HOST "cd $WD_REACT; git checkout ${CIRCLE_BRANCH}"
+              ssh $HOST "cd $WD_REACT; git merge ${CIRCLE_BRANCH}"
+            else
+              # 'devel' tagged version
+              ssh $HOST "cd $WD_REACT; git checkout devel"
+              ssh $HOST "cd $WD_REACT; git merge devel"
+            fi
+      - run:
+          name: Setup local configuration
+          command: |
+            source $ENV_VARS
+            echo $SERVER_URL
+            ssh $HOST "cd $WD_REACT; cp app/config/index.js.dist app/config/index.js"
+            ssh $HOST "cd $WD_REACT; sed -i "s/test.trilliontreecampaign.org/$SERVER_URL/" app/config/index.js"
+      # - run:
+      #     name: Build web client
+      #     command: |
+      #       source $ENV_VARS
+      #       echo $WD_REACT
+      #       ssh $HOST "cd $WD_REACT; /usr/bin/npm install"
+      #       if [[ "${CIRCLE_BRANCH}" == "master" ]]
+      #       then
+      #         ssh $HOST "cd $WD_REACT; /usr/bin/npm run build:prod_server"
+      #       else
+      #         ssh $HOST "cd $WD_REACT; /usr/bin/npm run build:server"
+      #       fi
+
+  # build the app in the cloud to check for eslint or compilation errors
   build_gitflow:
     docker:
       - image: circleci/node:10.11-jessie
@@ -89,6 +179,10 @@ jobs:
       - run:
           name: Install npm
           command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
       - run:
           name: Setup local configuration
           command: cp app/config/index.js.dist app/config/index.js
@@ -116,10 +210,6 @@ jobs:
                 --entry-file index.js \
                 --bundle-output ios-release.bundle \
                 --sourcemap-output ios-release.bundle.map
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - node_modules
 
 workflows:
   version: 2
@@ -132,7 +222,17 @@ workflows:
                 - master
                 - test
                 - staging
-                - devel
+            tags:
+              only: /^devel/
+      - build_server_repository:
+          filters:
+            branches:
+              only:
+                - master
+                - test
+                - staging
+            tags:
+              only: /^devel/
       - build_gitflow:
           filters:
             branches:


### PR DESCRIPTION
1. Besides building the branches `master`, `staging` and `test` in the cloud and installing the results into the server backends, this PR also updates the formerly used build folders on the backend server with the current version of these branches again, so that the Dashboard https://dashboard.trilliontreecampaign.org/home can show the correct state of the branch again (but it won't run webpack in order to save resources on the server).

2. Instead of using a branch `devel` (which have to be deleted after this PR is applied), this patch introduces just tagging a certain commit in the repository with a tag named `devel` in order to build this tagged version and install it on the devel backend.