### PR TITLE
disable eslint & widgets in webpack for developing

### DIFF
--- a/web/config/webpack.common.config.js
+++ b/web/config/webpack.common.config.js
@@ -14,11 +14,6 @@ const config = {
         }
       },
       {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: ['eslint-loader']
-      },
-      {
         test: /\.html$/,
         use: [
           {

--- a/web/config/webpack.dev.config.js
+++ b/web/config/webpack.dev.config.js
@@ -5,27 +5,29 @@ const path = require('path');
 
 module.exports = webpackMerge(commonConfig, {
   entry: {
-    bundle: ['babel-polyfill', path.join(__dirname, '../../index.web.js')],
-    widget: [
-      'babel-polyfill',
-      path.join(__dirname, '../widgets/basic/widget.js')
-    ],
-    treecounterwidget: [
-      'babel-polyfill',
-      path.join(__dirname, '../widgets/Treecounter/widget.js')
-    ],
-    donatetreewidget: [
-      'babel-polyfill',
-      path.join(__dirname, '../widgets/DonateTrees/widget.js')
-    ],
-    progressbarwidget: [
-      'babel-polyfill',
-      path.join(__dirname, '../widgets/progressbar/widget.js')
-      // ],
-      // ndviwidget: [
-      //   'babel-polyfill',
-      //   path.join(__dirname, '../widgets/NDVI/widget.js')
-    ]
+    bundle: ['babel-polyfill', path.join(__dirname, '../../index.web.js')]
+    /* uncomment these widgets if you want to work on them */
+    // widget: [
+    //   'babel-polyfill',
+    //   path.join(__dirname, '../widgets/basic/widget.js')
+    // ],
+    // treecounterwidget: [
+    //   'babel-polyfill',
+    //   path.join(__dirname, '../widgets/Treecounter/widget.js')
+    // ],
+    // donatetreewidget: [
+    //   'babel-polyfill',
+    //   path.join(__dirname, '../widgets/DonateTrees/widget.js')
+    // ],
+    // progressbarwidget: [
+    //   'babel-polyfill',
+    //   path.join(__dirname, '../widgets/progressbar/widget.js')
+    // ],
+    /* The following widget currently does not compile! */
+    // ndviwidget: [
+    //   'babel-polyfill',
+    //   path.join(__dirname, '../widgets/NDVI/widget.js')
+    // ]
   },
   output: {
     path: path.join(__dirname, '../dist'),

--- a/web/config/webpack.prod.config.js
+++ b/web/config/webpack.prod.config.js
@@ -33,7 +33,15 @@ module.exports = webpackMerge(commonConfig, {
     filename: '[name].js',
     publicPath: '/'
   },
-
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ['eslint-loader']
+      }
+    ]
+  },
   plugins: [
     new WebpackCleanupPlugin(),
     new webpack.LoaderOptionsPlugin({

--- a/web/config/webpack.prod_server.config.js
+++ b/web/config/webpack.prod_server.config.js
@@ -39,6 +39,15 @@ module.exports = webpackMerge(commonConfig, {
     publicPath: '/'
   },
   devtool: 'source-map',
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ['eslint-loader']
+      }
+    ]
+  },
   plugins: [
     new BugsnagBuildReporterPlugin({
       apiKey: '6f2971a9b077662912f61ae602716afd',

--- a/web/config/webpack.server.config.js
+++ b/web/config/webpack.server.config.js
@@ -34,6 +34,15 @@ module.exports = webpackMerge(commonConfig, {
     publicPath: '/'
   },
   devtool: 'source-map',
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ['eslint-loader']
+      }
+    ]
+  },
   plugins: [
     new WebpackCleanupPlugin(),
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
Speed up development of the web client by
- disable eslint check in webpack for development
- disable building the widgets for development