### PR TITLE
Fix #1261 retrieving slug either from project or omit the link

### DIFF
--- a/app/components/PlantProjects/PlantProjectFull.js
+++ b/app/components/PlantProjects/PlantProjectFull.js
@@ -71,7 +71,8 @@ class PlantProjectFull extends React.Component {
       homepageCaption: homepageCaption,
       videoUrl: videoUrl,
       geoLocation,
-      ndviUid
+      ndviUid,
+      tpoSlug
     } = this.props.plantProject;
     let projectImage = null;
 
@@ -83,6 +84,7 @@ class PlantProjectFull extends React.Component {
 
     const teaserProps = {
       tpoName: this.props.tpoName,
+      tpoSlug: tpoSlug,
       projectName,
       isCertified,
       projectImage
@@ -137,10 +139,10 @@ class PlantProjectFull extends React.Component {
               ) : null}
             </div>
           </div>
-          {teaserProps.tpoName && (
+          {teaserProps.tpoSlug && (
             <div className="row">
               <div className="teaser__tpoHeading">
-                <a onClick={() => this.updateRoute(teaserProps.tpoName)}>
+                <a onClick={() => this.updateRoute(teaserProps.tpoSlug)}>
                   {i18n.t('label.by_a_name') + ' ' + teaserProps.tpoName}
                 </a>
               </div>


### PR DESCRIPTION
- mostly the slug is already a property of a project (if loaded with `loadTpos` API call)
- for `PublicTreeCounter` of TPOs the slug is not part of the projects being loaded with the treecounter API call, but as the user is **already looking** at the tree counter the link can be omitted

Fix #1261
Replaces PR #1500

@jmiridis I think your additional work in https://github.com/Plant-for-the-Planet-org/treecounter-app/issues/1261#issuecomment-536377241 was not necessary to fix this bug. If it had not come with additional costs of computing resources for the backend you can keep it. Otherwise you can revert the change.