### PR TITLE
Feature/pledge event fix api call loop

### DIFF
--- a/app/actions/pledgeEventsAction.js
+++ b/app/actions/pledgeEventsAction.js
@@ -3,6 +3,7 @@ import { setPledgeEvents } from '../reducers/pledgeEventReducer';
 import { eventPledgeSchema } from '../schemas';
 import { normalize } from 'normalizr';
 import { mergeEntities } from '../reducers/entitiesReducer';
+
 export function fetchpledgeEventsAction() {
   return dispatch => {
     getRequest('public_pledgeEvents_get')

--- a/app/components/Pledge/index.js
+++ b/app/components/Pledge/index.js
@@ -79,7 +79,9 @@ export default class Pledge extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.pledges !== this.props.pledges) {
+    if (
+      JSON.stringify(prevProps.pledges) !== JSON.stringify(this.props.pledges)
+    ) {
       if (this.props.currentUserProfile) {
         this.setState({
           loggedIn: true

--- a/app/components/PledgeEvents/PledgeEvents.native.js
+++ b/app/components/PledgeEvents/PledgeEvents.native.js
@@ -55,7 +55,9 @@ class PledgeEvents extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.pledges !== this.props.pledges) {
+    if (
+      JSON.stringify(prevProps.pledges) !== JSON.stringify(this.props.pledges)
+    ) {
       if (this.props.currentUserProfile) {
         this.setState({
           loggedIn: true

--- a/app/components/PledgeEvents/PledgeEvents.native.js
+++ b/app/components/PledgeEvents/PledgeEvents.native.js
@@ -243,7 +243,7 @@ function FulfillPledgeButton(props) {
             source={nextArrowWhite}
             resizeMode="contain"
           />
-          <Text style={styles.continueText}>{i18n.t('label.donate2')}</Text>
+          <Text style={styles.continueText}>{i18n.t('label.donate')}</Text>
         </View>
       </TouchableOpacity>
     </View>

--- a/app/components/PledgeEvents/PledgeEvents.native.js
+++ b/app/components/PledgeEvents/PledgeEvents.native.js
@@ -243,7 +243,7 @@ function FulfillPledgeButton(props) {
             source={nextArrowWhite}
             resizeMode="contain"
           />
-          <Text style={styles.continueText}>{i18n.t('label.donate')}</Text>
+          <Text style={styles.continueText}>{i18n.t('label.donate2')}</Text>
         </View>
       </TouchableOpacity>
     </View>

--- a/app/components/TreecounterGraphics/Trillion.native.js
+++ b/app/components/TreecounterGraphics/Trillion.native.js
@@ -402,7 +402,7 @@ const mapDispatchToProps = dispatch => {
 };
 
 Trillion.propTypes = {
-  pledgeEvents: PropTypes.object.isRequired,
+  pledgeEvents: PropTypes.any,
   navigation: PropTypes.any,
   fetchpledgeEventsAction: PropTypes.func,
   fetchPublicPledgesAction: PropTypes.func

--- a/app/components/TreecounterGraphics/Trillion.native.js
+++ b/app/components/TreecounterGraphics/Trillion.native.js
@@ -248,7 +248,7 @@ class Trillion extends PureComponent {
                                   'app_pledge_events',
                                   navigation,
                                   {
-                                    slug: unfulfilledEvent.slug,
+                                    slug: unfulfilledEvent.eventSlug,
                                     plantProject: { id: -1 },
                                     treeCount: -1
                                   }

--- a/app/components/TreecounterGraphics/Trillion.native.js
+++ b/app/components/TreecounterGraphics/Trillion.native.js
@@ -58,10 +58,10 @@ class Trillion extends PureComponent {
         { key: 'world', title: i18n.t('label.world') },
         { key: 'leaderBoard', title: i18n.t('label.leaderboard') }
       ],
-      index: 0,
-      userPledges: {}
+      index: 0
     };
   }
+
   componentDidMount() {
     trillionCampaign()
       .then(({ data }) => {
@@ -109,9 +109,6 @@ class Trillion extends PureComponent {
             let stringPledges = JSON.parse(data);
             stringPledges = stringPledges.toString();
             this.props.fetchPublicPledgesAction(stringPledges);
-            this.setState({
-              userPledges: this.props.entities.eventPledge
-            });
           }
         })
         .catch(error => console.log(error));
@@ -119,11 +116,12 @@ class Trillion extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.entities.eventPledge !== this.props.entities.eventPledge) {
+    if (
+      JSON.stringify(prevProps.entities.eventPledge) !==
+      JSON.stringify(this.props.entities.eventPledge)
+    ) {
       if (this.props.userProfile) {
-        this.setState({
-          userPledges: this.props.entities.eventPledge
-        });
+        console.log('User Logged in');
       } else {
         fetchItem('pledgedEvent')
           .then(data => {
@@ -131,9 +129,6 @@ class Trillion extends PureComponent {
               let stringPledges = JSON.parse(data);
               stringPledges = stringPledges.toString();
               this.props.fetchPublicPledgesAction(stringPledges);
-              this.setState({
-                userPledges: this.props.entities.eventPledge
-              });
             }
           })
           .catch(error => console.log(error));

--- a/app/locales/en/pledgelabels.json
+++ b/app/locales/en/pledgelabels.json
@@ -27,6 +27,5 @@
   "allPledges": "All Pledges",
   "treesPledgedOn": "List of Trees Pledged on",
   "donateXTrees": "Donate {{treeCount}} Trees",
-  "increasePledgeMessage": "To increase your pledge, please enter an amount higher than {{treeCount}} trees. A tree costs {{treeCost}} {{currency}} and are planted in {{projectName}}",
-  "donate2": "Donate"
+  "increasePledgeMessage": "To increase your pledge, please enter an amount higher than {{treeCount}} trees. A tree costs {{treeCost}} {{currency}} and are planted in {{projectName}}"
 }

--- a/app/locales/en/pledgelabels.json
+++ b/app/locales/en/pledgelabels.json
@@ -27,5 +27,6 @@
   "allPledges": "All Pledges",
   "treesPledgedOn": "List of Trees Pledged on",
   "donateXTrees": "Donate {{treeCount}} Trees",
-  "increasePledgeMessage": "To increase your pledge, please enter an amount higher than {{treeCount}} trees. A tree costs {{treeCost}} {{currency}} and are planted in {{projectName}}"
+  "increasePledgeMessage": "To increase your pledge, please enter an amount higher than {{treeCount}} trees. A tree costs {{treeCost}} {{currency}} and are planted in {{projectName}}",
+  "donate2": "Donate"
 }


### PR DESCRIPTION
- prevent API loop for logged out users who did a pledge by using value comparison for `this.props.entities.eventPledge` instead of comparing objects with previous properties
- prevent API loop for logged out users by using value comparison for `this.props.pledges` against `prevProps.pledges` as well
- prevent warning for required `pledgeEvents` in component `Trillion` making it not required
- removed unused code setting the state value `userPledges`
- fixed wrong slug value for unfulfilled pledge events in Trillion component

Fix #1630