### PR TITLE
Fix adding too much user profile information into forms and sending to API

### DIFF
--- a/app/components/DonateTrees/index.js
+++ b/app/components/DonateTrees/index.js
@@ -238,7 +238,9 @@ export default class DonateTrees extends Component {
       if (value) {
         if (this.state.modeReceipt === 'individual') {
           receipt['receiptIndividual'] = value;
+          receipt['receiptCompany'] = {};
         } else {
+          receipt['receiptIndividual'] = {};
           receipt['receiptCompany'] = value;
         }
 
@@ -277,7 +279,9 @@ export default class DonateTrees extends Component {
       if (value) {
         if (this.state.modeReceipt === 'individual') {
           receipt['receiptIndividual'] = value;
+          receipt['receiptCompany'] = {};
         } else {
+          receipt['receiptIndividual'] = {};
           receipt['receiptCompany'] = value;
         }
         this.setState({

--- a/app/components/DonateTrees/index.js
+++ b/app/components/DonateTrees/index.js
@@ -28,6 +28,8 @@ import PaymentSelector from '../Payment/PaymentSelector';
 import DescriptionHeading from '../Common/Heading/DescriptionHeading';
 import { paymentFee } from '../../helpers/utils';
 
+import donateTreesSchema from '../../server/formSchemas/donateTrees';
+
 let TCombForm = t.form.Form;
 
 const pageHeadings = [
@@ -80,11 +82,24 @@ export default class DonateTrees extends Component {
         props.currentUserProfile.type === 'individual'
           ? 'individual'
           : 'company';
-      if (modeReceipt === 'individual') {
-        receipt['receiptIndividual'] = props.currentUserProfile;
-      } else {
-        receipt['receiptCompany'] = props.currentUserProfile;
-      }
+
+      // prefill individual fields
+      receipt['receiptIndividual'] = {};
+      const receiptIndividualFields = Object.keys(
+        donateTreesSchema.properties.receiptIndividual.properties
+      );
+      receiptIndividualFields.forEach(item => {
+        receipt['receiptIndividual'][item] = props.currentUserProfile[item];
+      });
+
+      // prefill company fields
+      receipt['receiptCompany'] = {};
+      const receiptCompanyFields = Object.keys(
+        donateTreesSchema.properties.receiptCompany.properties
+      );
+      receiptCompanyFields.forEach(item => {
+        receipt['receiptCompany'][item] = props.currentUserProfile[item];
+      });
     } else {
       modeReceipt = '';
     }


### PR DESCRIPTION
Fixes #1639

Changes in this pull request:
- only copy required fields from user profile into forms for donations
- only allow individual or company data, but not both 
- tested for native apps which is implemented differently and works well

I still experience the problem, that if you go back in the donation process and change the address, no second /create call is made to the API, so I am unsure if the change of the address would affect anything.