### PR TITLE
try adding support for jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ package-lock.json
 # Bundle artifact
 *.jsbundle
 
+#jest
+coverage
+
 #app build
 web/prod
 web/server

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+// jest.config.js
+module.exports = {
+  verbose: true,
+  clearMocks: true,
+  collectCoverage: true,
+  testURL: 'http://localhost/',
+  transform: {
+    '^.+\\.jsx?$': 'babel7-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint app",
     "lint:errors": "eslint app --quiet",
     "lint:json": "eslint . --ext .json",
+    "test": "jest",
     "postinstall": "grep -r --include=*.java -l 'android.support.v7' ./node_modules/react-native-image-picker | sort | uniq | xargs perl -e 's/android.support.v7/androidx.appcompat/' -pi && grep -r --include=*.java -l 'android.support.v4' ./node_modules/react-native-image-picker | sort | uniq | xargs perl -e 's/android.support.v4/androidx.core/' -pi && grep -r --include=*.java -l 'android.support' ./node_modules/react-native-image-picker | sort | uniq | xargs perl -e 's/android.support/androidx/' -pi && grep --include=*.java -r -l 'android.support' ./node_modules/react-native-youtube | sort | uniq | xargs perl -e 's/android.support/androidx/' -pi"
   },
   "lint-staged": {
@@ -121,7 +122,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",
-    "babel-jest": "22.4.3",
+    "babel-jest": "^22.4.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-remove-console": "^6.9.4",
@@ -131,6 +132,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-native": "^4.0.1",
     "babel-preset-stage-2": "^6.24.1",
+    "babel7-jest": "^1.0.1",
     "eslint": "^6.6.0",
     "eslint-loader": "^2.2.1",
     "eslint-plugin-json": "1.4.0",
@@ -143,7 +145,7 @@
     "html-webpack-plugin": "^4.0.0-beta.8",
     "husky": "^0.14.3",
     "image-webpack-loader": "^6.0.0",
-    "jest": "22.4.3",
+    "jest": "^22.4.3",
     "license-checker": "^20.2.0",
     "lint-staged": "^7.0.5",
     "live-server": "^1.2.1",


### PR DESCRIPTION
Fixes #1679 and #1302 

Changes in this pull request:
- trying to added support for jest with running `npm run test` or `jest` (after having installed jest globally with `npm install jest --global`)

Problem:
```
 FAIL  __tests__/App-test.js
  ● Test suite failed to run

    Cannot find module 'warnOnce' from 'react-native-implementation.js'
      
      at Resolver.resolveModule (node_modules/jest/node_modules/jest-resolve/build/index.js:169:17)
      at Object.<anonymous> (node_modules/react-native/Libraries/react-native/react-native-implementation.js:14:18)
```
I tried some stuff from https://github.com/facebook/jest/issues/6933 but did not succeed.