### PR TITLE
feature/content loader new 1

### DIFF
--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -51,20 +51,20 @@ const LeaderBoardLoader = () => (
 );
 const WorldLoader = () => (
   <ContentLoader
-    height={550}
-    width={500}
+    height={HEIGHT}
+    width={WIDTH}
     speed={3}
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
   >
-    <Rect x="100" y="3" rx="10" ry="10" width="300" height="180" />
-    <Rect x="100" y="190" rx="10" ry="10" width="140" height="20" />
-    <Rect x="100" y="215" rx="10" ry="10" width="300" height="20" />
-    <Rect x="100" y="240" rx="10" ry="10" width="250" height="20" />
-    <Rect x="100" y="270" rx="10" ry="10" width="300" height="180" />
-    <Rect x="100" y="460" rx="10" ry="10" width="140" height="20" />
-    <Rect x="100" y="490" rx="10" ry="10" width="300" height="20" />
-    <Rect x="100" y="520" rx="10" ry="10" width="250" height="20" />
+    <Rect x="30" y="3" rx="10" ry="10" width="85%" height="180" />
+    <Rect x="30" y="190" rx="10" ry="10" width="45%" height="20" />
+    <Rect x="30" y="215" rx="10" ry="10" width="75%" height="20" />
+    <Rect x="30" y="240" rx="10" ry="10" width="70%" height="20" />
+    <Rect x="30" y="270" rx="10" ry="10" width="85%" height="180" />
+    <Rect x="30" y="460" rx="10" ry="10" width="45%" height="20" />
+    <Rect x="30" y="490" rx="10" ry="10" width="70%" height="20" />
+    <Rect x="30" y="520" rx="10" ry="10" width="85%" height="20" />
   </ContentLoader>
 );
 const ProfileLoader = () => (

--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -7,20 +7,20 @@ const HEIGHT = Dimensions.get('window').height;
 const WIDTH = Dimensions.get('window').width;
 const CompetitionLoader = () => (
   <ContentLoader
-    height={550}
-    width={500}
+    height={HEIGHT}
+    width={WIDTH}
     speed={3}
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
   >
-    <Rect x="100" y="3" rx="10" ry="10" width="300" height="180" />
-    <Rect x="100" y="190" rx="10" ry="10" width="140" height="20" />
-    <Rect x="100" y="215" rx="10" ry="10" width="300" height="20" />
-    <Rect x="100" y="240" rx="10" ry="10" width="250" height="20" />
-    <Rect x="100" y="270" rx="10" ry="10" width="300" height="180" />
-    <Rect x="100" y="460" rx="10" ry="10" width="140" height="20" />
-    <Rect x="100" y="490" rx="10" ry="10" width="300" height="20" />
-    <Rect x="100" y="520" rx="10" ry="10" width="250" height="20" />
+    <Rect x="30" y="3" rx="10" ry="10" width="85%" height="180" />
+    <Rect x="30" y="190" rx="10" ry="10" width="35%" height="20" />
+    <Rect x="30" y="215" rx="10" ry="10" width="85%" height="20" />
+    <Rect x="30" y="240" rx="10" ry="10" width="75%" height="20" />
+    <Rect x="30" y="270" rx="10" ry="10" width="85%" height="180" />
+    <Rect x="30" y="460" rx="10" ry="10" width="35%" height="20" />
+    <Rect x="30" y="490" rx="10" ry="10" width="85%" height="20" />
+    <Rect x="30" y="520" rx="10" ry="10" width="75%" height="20" />
   </ContentLoader>
 );
 const SingleCompetitionLoader = () => (
@@ -186,11 +186,13 @@ const ProjectSingleLoader = () => (
 );
 
 {
-  /*const DefaultLoader = () => (
-  <View style={[loadingIndicatorStyle, containerStyle]}>
-    <Image source={loadingBar} alt={i18n.t('label.loading')} />
-  </View>
-);*/
+  /*
+    const DefaultLoader = () => (
+    <View style={[loadingIndicatorStyle, containerStyle]}>
+      <Image source={loadingBar} alt={i18n.t('label.loading')} />
+    </View>
+  );
+  */
 }
 
 const PublicTreeCounterContentLoader = () => (
@@ -215,19 +217,27 @@ const PledgeEventsContentLoader = () => (
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
   >
-    <Circle cx="53" cy="43" r="30" />
-    <Rect x="30" y="94" rx="4" ry="4" width="70%" height="13" />
-    <Rect x="30" y="118" rx="4" ry="4" width="40%" height="13" />
-    <Rect x="30" y="142" rx="4" ry="4" width="80%" height="13" />
-    <Rect x="30" y="170" rx="0" ry="0" width="80%" height="41" />
-    <Rect x="30" y="227" rx="0" ry="0" width="80%" height="41" />
-    <Rect x="30" y="284" rx="4" ry="4" width="60%" height="13" />
-    <Rect x="30" y="307" rx="4" ry="4" width="80%" height="11" />
-    <Rect x="30" y="330" rx="4" ry="4" width="35%" height="13" />
+    <View>
+      <Rect x="30" y="10%" rx="5" ry="5" width="45" height="28" />
+      <Rect x="30" y="17%" rx="4" ry="4" width="60%" height="12" />
+      <Rect x="30" y="21%" rx="3" ry="3" width="75%" height="12" />
+      <Rect x="30" y="26%" rx="3" ry="3" width="85%" height="6" />
+      <Rect x="30" y="30%" rx="3" ry="3" width="85%" height="6" />
+      <Rect x="30" y="34%" rx="3" ry="3" width="75%" height="6" />
+      <Rect x="30" y="45%" rx="5" ry="5" width="38%" height="36" />
+      <Rect x="50%" y="45%" rx="5" ry="5" width="35%" height="36" />
+      <Rect x="30" y="80%" rx="5" ry="5" width="131" height="47" />
+      <Rect x="50%" y="80%" rx="5" ry="5" width="131" height="47" />
+      <Rect x="30" y="60%" rx="3" ry="3" width="301" height="6" />
+      <Rect x="30" y="63%" rx="3" ry="3" width="301" height="6" />
+      <Rect x="30" y="66%" rx="3" ry="3" width="301" height="6" />
+      <Rect x="30" y="69%" rx="3" ry="3" width="301" height="6" />
+    </View>
   </ContentLoader>
 );
 const ContentLoading = props => {
   const { screen } = props;
+  console.log(screen, 'screenscreenscreenscreenscreenscreen');
   return (
     <View style={loadingIndicatorStyle}>
       {screen === 'AppHome' && <WorldLoader />}
@@ -261,5 +271,3 @@ const loadingIndicatorStyle = {
 };*/
 }
 export default ContentLoading;
-
-export { PublicTreeCounterContentLoader, SingleCompetitionLoader };

--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -194,10 +194,10 @@ const PublicTreeCounterContentLoader = () => (
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
   >
-    <Circle cx="50" cy="60" r="30" />
-    <Rect x="100" y="40" rx="4" ry="4" width="220" height="13" />
-    <Rect x="100" y="70" rx="4" ry="4" width="100" height="13" />
-    <Circle cx="160" cy="270" r="106" />
+    <Circle cx="15%" cy="60" r="30" />
+    <Rect x="30%" y="40" rx="4" ry="4" width="60%" height="13" />
+    <Rect x="30%" y="70" rx="4" ry="4" width="30%" height="13" />
+    <Circle cx="50%" cy="50%" r="106" />
   </ContentLoader>
 );
 const PledgeEventsContentLoader = () => (

--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Image, View, Dimensions } from 'react-native';
+import { View, Dimensions } from 'react-native';
 import ContentLoader from 'react-native-content-loader';
-import { Circle, Rect, Text } from 'react-native-svg';
-import i18n from '../../locales/i18n.js';
-import { loadingBar } from '../../assets';
+import { Circle, Rect } from 'react-native-svg';
 
 const HEIGHT = Dimensions.get('window').height;
 const WIDTH = Dimensions.get('window').width;
@@ -180,11 +178,13 @@ const ProjectSingleLoader = () => (
   </ContentLoader>
 );
 
-const DefaultLoader = () => (
+{
+  /*const DefaultLoader = () => (
   <View style={[loadingIndicatorStyle, containerStyle]}>
     <Image source={loadingBar} alt={i18n.t('label.loading')} />
   </View>
-);
+);*/
+}
 
 const PublicTreeCounterContentLoader = () => (
   <ContentLoader
@@ -246,11 +246,13 @@ const loadingIndicatorStyle = {
   alignItems: 'center',
   marginTop: '5%'
 };
-const containerStyle = {
+{
+  /*const containerStyle = {
   flex: 1,
   alignItems: 'center',
   justifyContent: 'center'
-};
+};*/
+}
 export default ContentLoading;
 
 export { PublicTreeCounterContentLoader };

--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Image, View } from 'react-native';
+import { Image, View, Dimensions } from 'react-native';
 import ContentLoader from 'react-native-content-loader';
-import { Circle, Rect } from 'react-native-svg';
+import { Circle, Rect, Text } from 'react-native-svg';
 import i18n from '../../locales/i18n.js';
 import { loadingBar } from '../../assets';
 
+const HEIGHT = Dimensions.get('window').height;
+const WIDTH = Dimensions.get('window').width;
 const CompetitionLoader = () => (
   <ContentLoader
     height={550}
@@ -21,6 +23,23 @@ const CompetitionLoader = () => (
     <Rect x="100" y="460" rx="10" ry="10" width="140" height="20" />
     <Rect x="100" y="490" rx="10" ry="10" width="300" height="20" />
     <Rect x="100" y="520" rx="10" ry="10" width="250" height="20" />
+  </ContentLoader>
+);
+const SingleCompetitionLoader = () => (
+  <ContentLoader
+    height={550}
+    width={500}
+    speed={3}
+    primaryColor="#f3f3f3"
+    secondaryColor="#ecebeb"
+  >
+    <Rect x="100" y="3" rx="10" ry="10" width="300" height="180" />
+    <Rect x="100" y="190" rx="10" ry="10" width="140" height="20" />
+    <Rect x="100" y="217" rx="10" ry="10" width="300" height="20" />
+    <Rect x="100" y="244" rx="10" ry="10" width="250" height="20" />
+    <Rect x="100" y="274" rx="10" ry="10" width="140" height="20" />
+    <Rect x="100" y="304" rx="10" ry="10" width="300" height="20" />
+    <Rect x="100" y="334" rx="10" ry="10" width="250" height="20" />
   </ContentLoader>
 );
 const LeaderBoardLoader = () => (
@@ -167,6 +186,21 @@ const DefaultLoader = () => (
   </View>
 );
 
+const PublicTreeCounterContentLoader = () => (
+  <ContentLoader
+    height={HEIGHT}
+    width={WIDTH}
+    speed={3}
+    primaryColor="#f3f3f3"
+    secondaryColor="#ecebeb"
+  >
+    <Circle cx="50" cy="60" r="30" />
+    <Rect x="100" y="40" rx="4" ry="4" width="220" height="13" />
+    <Rect x="100" y="70" rx="4" ry="4" width="100" height="13" />
+    <Circle cx="160" cy="270" r="106" />
+  </ContentLoader>
+);
+
 const ContentLoading = props => {
   const { screen } = props;
   return (
@@ -174,14 +208,17 @@ const ContentLoading = props => {
       {screen === 'AppHome' && <WorldLoader />}
       {screen === 'LeaderBoard' && <LeaderBoardLoader />}
       {screen === 'Competition' && <CompetitionLoader />}
-      {screen === 'worldLoader' && <DefaultLoader />}
+      {screen === 'SingleCompetition' && <SingleCompetitionLoader />}
+      {screen === 'PublicTreeCounterContentLoader' && (
+        <PublicTreeCounterContentLoader />
+      )}
       {screen === 'profileLoader' && <ProfileLoader />}
       {screen === 'publicProfileLoader' && <PublicProfileLoader />}
       {screen === 'competitionListLoader' && <CompetitionListLoader />}
       {screen === 'competitionSingleLoader' && <CompetitionSingleLoader />}
       {screen === 'projectListLoader' && <ProjectListLoader />}
+      {screen === 'worldLoader' && <WorldLoader />}
       {screen === 'projectSingleLoader' && <ProjectSingleLoader />}
-      {screen === 'defaultLoader' && <DefaultLoader />}
     </View>
   );
 };
@@ -196,3 +233,5 @@ const containerStyle = {
   justifyContent: 'center'
 };
 export default ContentLoading;
+
+export { PublicTreeCounterContentLoader };

--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -31,13 +31,20 @@ const SingleCompetitionLoader = () => (
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
   >
-    <Rect x="30" y="3" rx="10" ry="10" width="85%" height="180" />
-    <Rect x="30" y="190" rx="10" ry="10" width="45%" height="20" />
-    <Rect x="30" y="217" rx="10" ry="10" width="85%" height="20" />
-    <Rect x="30" y="244" rx="10" ry="10" width="75%" height="20" />
-    <Rect x="30" y="274" rx="10" ry="10" width="45%" height="20" />
-    <Rect x="30" y="304" rx="10" ry="10" width="85%" height="20" />
-    <Rect x="30" y="334" rx="10" ry="10" width="65%" height="20" />
+    <Rect x="30" y="14" rx="10" ry="10" width="85%" height="150" />
+    <Rect x="30" y="173" rx="10" ry="10" width="85%" height="20" />
+    <Rect x="30" y="240" rx="5" ry="5" width="85%" height="10" />
+    <Rect x="30" y="260" rx="5" ry="5" width="85%" height="10" />
+    <Rect x="30" y="280" rx="5" ry="5" width="75%" height="10" />
+    <Rect x="30" y="312" rx="5" ry="5" width="25%" height="30" />
+    <Circle cx="53" cy="380" r="16" />
+    <Rect x="80" y="375" rx="5" ry="5" width="70%" height="10" />
+    <Circle cx="53" cy="420" r="16" />
+    <Rect x="80" y="415" rx="5" ry="5" width="70%" height="10" />
+    <Circle cx="55" cy="460" r="16" />
+    <Rect x="80" y="455" rx="5" ry="5" width="70%" height="10" />
+    <Circle cx="55" cy="500" r="16" />
+    <Rect x="80" y="495" rx="5" ry="5" width="70%" height="10" />
   </ContentLoader>
 );
 const LeaderBoardLoader = () => (
@@ -255,4 +262,4 @@ const loadingIndicatorStyle = {
 }
 export default ContentLoading;
 
-export { PublicTreeCounterContentLoader };
+export { PublicTreeCounterContentLoader, SingleCompetitionLoader };

--- a/app/components/Common/ContentLoader.native.js
+++ b/app/components/Common/ContentLoader.native.js
@@ -27,19 +27,19 @@ const CompetitionLoader = () => (
 );
 const SingleCompetitionLoader = () => (
   <ContentLoader
-    height={550}
-    width={500}
+    height={HEIGHT}
+    width={WIDTH}
     speed={3}
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
   >
-    <Rect x="100" y="3" rx="10" ry="10" width="300" height="180" />
-    <Rect x="100" y="190" rx="10" ry="10" width="140" height="20" />
-    <Rect x="100" y="217" rx="10" ry="10" width="300" height="20" />
-    <Rect x="100" y="244" rx="10" ry="10" width="250" height="20" />
-    <Rect x="100" y="274" rx="10" ry="10" width="140" height="20" />
-    <Rect x="100" y="304" rx="10" ry="10" width="300" height="20" />
-    <Rect x="100" y="334" rx="10" ry="10" width="250" height="20" />
+    <Rect x="30" y="3" rx="10" ry="10" width="85%" height="180" />
+    <Rect x="30" y="190" rx="10" ry="10" width="45%" height="20" />
+    <Rect x="30" y="217" rx="10" ry="10" width="85%" height="20" />
+    <Rect x="30" y="244" rx="10" ry="10" width="75%" height="20" />
+    <Rect x="30" y="274" rx="10" ry="10" width="45%" height="20" />
+    <Rect x="30" y="304" rx="10" ry="10" width="85%" height="20" />
+    <Rect x="30" y="334" rx="10" ry="10" width="65%" height="20" />
   </ContentLoader>
 );
 const LeaderBoardLoader = () => (
@@ -200,7 +200,25 @@ const PublicTreeCounterContentLoader = () => (
     <Circle cx="160" cy="270" r="106" />
   </ContentLoader>
 );
-
+const PledgeEventsContentLoader = () => (
+  <ContentLoader
+    height={HEIGHT}
+    width={WIDTH}
+    speed={3}
+    primaryColor="#f3f3f3"
+    secondaryColor="#ecebeb"
+  >
+    <Circle cx="53" cy="43" r="30" />
+    <Rect x="30" y="94" rx="4" ry="4" width="70%" height="13" />
+    <Rect x="30" y="118" rx="4" ry="4" width="40%" height="13" />
+    <Rect x="30" y="142" rx="4" ry="4" width="80%" height="13" />
+    <Rect x="30" y="170" rx="0" ry="0" width="80%" height="41" />
+    <Rect x="30" y="227" rx="0" ry="0" width="80%" height="41" />
+    <Rect x="30" y="284" rx="4" ry="4" width="60%" height="13" />
+    <Rect x="30" y="307" rx="4" ry="4" width="80%" height="11" />
+    <Rect x="30" y="330" rx="4" ry="4" width="35%" height="13" />
+  </ContentLoader>
+);
 const ContentLoading = props => {
   const { screen } = props;
   return (
@@ -219,6 +237,7 @@ const ContentLoading = props => {
       {screen === 'projectListLoader' && <ProjectListLoader />}
       {screen === 'worldLoader' && <WorldLoader />}
       {screen === 'projectSingleLoader' && <ProjectSingleLoader />}
+      {screen === 'PledgeEvents' && <PledgeEventsContentLoader />}
     </View>
   );
 };

--- a/app/components/Competition/CompetitionFull.native.js
+++ b/app/components/Competition/CompetitionFull.native.js
@@ -49,7 +49,7 @@ class CompetitionFull extends React.Component {
       button2 = null;
     const competitionDetail = this.props.competitionDetail;
 
-    console.log(competitionDetail);
+    console.log(' CompetitionFull ', competitionDetail);
     let participantCount = 0,
       requestCount = 0,
       // eslint-disable-next-line no-unused-vars
@@ -196,7 +196,7 @@ class CompetitionFull extends React.Component {
     return (
       <View style={snippetStyles.flexView}>
         {contentloader ? (
-          <LoadingIndicator contentLoader screen={'Competition'} />
+          <LoadingIndicator contentLoader screen={'SingleCompetition'} />
         ) : (
           <KeyboardAwareScrollView
             keyboardDismissMode="on-drag"

--- a/app/components/PledgeEvents/PledgeEvents.native.js
+++ b/app/components/PledgeEvents/PledgeEvents.native.js
@@ -138,7 +138,7 @@ class PledgeEvents extends Component {
 
     let slug = this.state.slug;
     return this.state.loading ? (
-      <LoadingIndicator />
+      <LoadingIndicator contentLoader screen={'PledgeEvents'} />
     ) : (
       <SafeAreaView style={styles.peRootView}>
         <View>

--- a/app/components/PledgeEvents/UnfulfilledPledgeEvent.native.js
+++ b/app/components/PledgeEvents/UnfulfilledPledgeEvent.native.js
@@ -53,7 +53,7 @@ class UnfulfilledPledgeEvents extends Component {
   render() {
     const unfulfilledEvent = this.props.navigation.getParam('unfulfilledEvent');
     return this.state.loading ? (
-      <LoadingIndicator />
+      <LoadingIndicator contentLoader screen={'PledgeEvents'} />
     ) : (
       <View style={styles.peRootView}>
         <ScrollView contentContainerStyle={styles.peRootScrollView}>

--- a/app/components/PublicTreeCounter/PublicTreecounter.native.js
+++ b/app/components/PublicTreeCounter/PublicTreecounter.native.js
@@ -121,7 +121,12 @@ class PublicTreeCounter extends React.Component {
   render() {
     const { treecounter, currentUserProfile, navigation } = this.props;
     if (null === treecounter) {
-      return <LoadingIndicator contentLoader screen="worldLoader" />;
+      return (
+        <LoadingIndicator
+          contentLoader
+          screen="PublicTreeCounterContentLoader"
+        />
+      );
     }
 
     const { userProfile, displayName: caption } = treecounter;

--- a/index.native.js
+++ b/index.native.js
@@ -2,6 +2,7 @@ import { AppRegistry } from 'react-native';
 import App from './app/components/App';
 import './ReactotronConfig';
 /* app.js */
+import { PublicTreeCounterContentLoader } from './app/components/Common/ContentLoader.native';
 
 console.disableYellowBox = true;
 console.ignoredYellowBox = ['Warning: Each', 'Warning: Failed'];


### PR DESCRIPTION
Fixes #1719

Changes in this pull request:
 Create Separate Loader for Single Competition Page

 Remove existing loading animation where the content loader has been implemented.

 Implement content loader on Public Profile try clicking on a competition participant. or search a name from search bar.

 Implement content loader, or remove loading icon, on first app opening page.

 Implement relative width for content loader boxes. So they don't appear too alien to the app's UI.

 Content Loader for PledgeEvents