### PR TITLE
Reverts menu to v1.1

### DIFF
--- a/app/layouts/sideMenu.js
+++ b/app/layouts/sideMenu.js
@@ -6,7 +6,7 @@ const PublicSideMenuSchema = menuNameParam => {
   return new Observable(observe => {
     getRequest('public_menu_get', {
       category: menuNameParam,
-      version: 'v1.4'
+      version: 'v1.1'
     })
       .then(({ data }) => {
         observe.next(data);
@@ -20,7 +20,7 @@ const AuthenticatedSideMenuSchema = menuNameParam => {
   return new Observable(observe => {
     getAuthenticatedRequest('data_menu_get', {
       category: menuNameParam,
-      version: 'v1.4'
+      version: 'v1.1'
     })
       .then(({ data }) => {
         observe.next(data);


### PR DESCRIPTION
The initial idea for the 1.4 update was to remove menu items from the mobile apps; however they are now not dependent on api anymore.

Fixes issue with My Trees not appearing in web.