### PR TITLE
added sync and async getLocale functions for native apps

### DIFF
--- a/app/actions/apiRouting.js
+++ b/app/actions/apiRouting.js
@@ -1,13 +1,13 @@
 const routes = require('../server/routes/fos_js_routes.json');
 import Routing from './router.min.js';
 import { context } from '../config';
-import { getLocale } from './getLocale';
+import { getLocaleAsync } from './getLocale';
 import { getCdnMediaUrl } from './fetchLocation';
 Routing.setRoutingData(routes);
 
 export const getApiRoute = async (routeName, params) => {
   const { scheme, host, base: baseUrl } = context;
-  let locale = await getLocale();
+  let locale = await getLocaleAsync();
   console.log('-------------------- Api calling with ', locale);
   const serverName = `${scheme}://${host}`;
   params =

--- a/app/actions/getLocale.native.js
+++ b/app/actions/getLocale.native.js
@@ -17,10 +17,18 @@ export async function initLocale() {
   cache.locale = await guessLocale();
 }
 
-export async function getLocale() {
+export async function getLocaleAsync() {
   // console.log('getLocale', cache.locale);
   if (!cache.locale) {
     await initLocale();
+  }
+  return cache.locale;
+}
+
+export function getLocale() {
+  // console.log('getLocale', cache.locale);
+  if (!cache.locale) {
+    initLocale();
   }
   return cache.locale;
 }


### PR DESCRIPTION
Fixes #1884

@mahmed0715 can you please have a look as you made the change in https://github.com/Plant-for-the-Planet-org/treecounter-app/commit/00f2209e which broke the localization for numbers and dates. 
I think we don't want to change all the number and date formatting functions to be async, so I decided to have both a sync and async method to get the locale value using async for the API and sync for everything else until now.