### PR TITLE
upgrade react-tooltip

### DIFF
--- a/app/components/Header/UserDetails.js
+++ b/app/components/Header/UserDetails.js
@@ -49,7 +49,12 @@ const UserDetails = ({
             <a data-tip data-for="dedicate-trees-icon">
               <img src={questionmark_orange} />
             </a>
-            <ReactTooltip id="dedicate-trees-icon" effect="solid" type="dark">
+            <ReactTooltip
+              id="dedicate-trees-icon"
+              place="left"
+              effect="solid"
+              type="dark"
+            >
               <span className="tooltip-text">
                 {i18n.t('label.dedicate_tootltip')}
               </span>

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "react-slick": "^0.23.1",
     "react-smartbanner": "^5.1.4",
     "react-stripe-elements": "^5.1.0",
-    "react-tooltip": "^3.11.1",
+    "react-tooltip": "^4.0.3",
     "react-youtube": "^7.6.0",
     "recaptcha-v3-react": "^2.0.3",
     "redux": "^4.0.4",

--- a/web/widgets/Treecounter/app/components/App.js
+++ b/web/widgets/Treecounter/app/components/App.js
@@ -4,7 +4,7 @@ import TreecounterGraphicsText from '../../../../../app/components/TreecounterGr
 import SecondaryButton from '../../../../../app/components/Common/Button/SecondaryButton';
 import { SideMenuImage } from '../../../../../app/assets';
 import PropTypes from 'prop-types';
-import ReactTooltipStyle from '../../../../../node_modules/react-tooltip/dist/style';
+// import ReactTooltipStyle from '../../../../../node_modules/react-tooltip/dist/style';
 import i18n from '../../../../../app/locales/i18n.js';
 import { getLocalRoute } from '../../../../../app/actions/apiRouting';
 import TreecounterHeader from '../../../../../app/components/PublicTreeCounter/TreecounterHeader';
@@ -112,7 +112,8 @@ export default class App extends Component {
           {/* Apply CSS hooks here */}
           <style>{style}</style>
           {/* Apply React Tooltip Library CSS */}
-          <style>{ReactTooltipStyle}</style>
+          {/* TODO: removed as not existing any more, replace with something else?
+             <style>{ReactTooltipStyle}</style> */}
           <div className="pftp-widget-row">
             <div className={'pftp-widget-img__container'}>
               {this.props.showGraphics && (

--- a/web/widgets/progressbar/app/components/App.js
+++ b/web/widgets/progressbar/app/components/App.js
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import PlantedProgressBar from '../../../../../app/components/PlantProjects/PlantedProgressbar';
 import SecondaryButton from '../../../../../app/components/Common/Button/SecondaryButton';
 import { tree } from '../../../../../app/assets';
-
 import PropTypes from 'prop-types';
-import ReactTooltipStyle from '../../../../../node_modules/react-tooltip/dist/style';
+// import ReactTooltipStyle from '../../../../../node_modules/react-tooltip/dist/style';
 import i18n from '../../../../../app/locales/i18n.js';
 import { getLocalRoute } from '../../../../../app/actions/apiRouting';
 
@@ -51,7 +50,8 @@ export default class App extends Component {
           {/* Apply CSS hooks here */}
           <style>{style}</style>
           {/* Apply React Tooltip Library CSS */}
-          <style>{ReactTooltipStyle}</style>
+          {/* TODO: removed as not existing any more, replace with something else?
+             <style>{ReactTooltipStyle}</style> */}
           <div className="widget-container" id={'widget-container'}>
             {this.props.showGraphics && (
               <div className={'pftp-widget-img__container'}>


### PR DESCRIPTION
Just upgrade react-tooltip (I hoped that would fix the CircleCI build, but it doesn't).
Found the error in a non existing file `ReactTooltipStyle` and removed it. Our widget are not ready to be used anymore and need to be refactored.