### PR TITLE
Fix date chooser input problem in competitions

### DIFF
--- a/app/components/Competition/Tabs/formComponents.native.js
+++ b/app/components/Competition/Tabs/formComponents.native.js
@@ -307,7 +307,9 @@ export function CompetitionDatePicker(props) {
         onConfirm={date => {
           (date = date || props.endDate),
             setShowDatePicker(false),
-            props.setFieldValue('endDate', date);
+            props.setFieldValue(
+              formatDate(formatDateToMySQL(new Date(date)), 'yyyy-MM-dd')
+            );
         }}
         onCancel={() => setShowDatePicker(false)}
         minimumDate={new Date(new Date().valueOf() + 1000 * 3600 * 24)}

--- a/app/components/Competition/editFormComponents.native.js
+++ b/app/components/Competition/editFormComponents.native.js
@@ -378,7 +378,9 @@ export function CompetitionDatePicker(props) {
         onConfirm={date => {
           (date = date || props.endDate),
             setShowDatePicker(false),
-            props.setFieldValue('endDate', date);
+            props.setFieldValue(
+              formatDate(formatDateToMySQL(new Date(date)), 'yyyy-MM-dd')
+            );
         }}
         onCancel={() => setShowDatePicker(false)}
         minimumDate={new Date(new Date().valueOf() + 1000 * 3600 * 24)}


### PR DESCRIPTION
Fixes #1678

Convert date to get rid of time value, but just have the actual day the same as done here https://github.com/Plant-for-the-Planet-org/treecounter-app/blob/97cf7ae25c957041883f57899e70960116167aa8/app/components/RegisterTrees/formComponents.native.js#L858
(Of course abstracting this into something unique for our app would be even cooler.)

