### PR TITLE
Fixed loading missing project details for donation container

### DIFF
--- a/app/containers/DonateTrees/index.js
+++ b/app/containers/DonateTrees/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { debug } from '../../debug';
 import { supportTreecounterAction } from '../../actions/supportTreecounterAction';
 import {
+  selectedPlantProjectIdSelector,
   selectedPlantProjectSelector,
   selectedTpoSelector,
   currentUserProfileSelector,
@@ -75,9 +76,12 @@ class DonationTreesContainer extends PureComponent {
     let selectedProjectId = undefined;
     if (this.props.match) {
       selectedProjectId = parseInt(this.props.match.params.id);
-      selectedProjectId &&
-        (await this.props.loadProject({ id: selectedProjectId }));
+    } else {
+      selectedProjectId = this.props.selectedPlantProjectId;
     }
+    selectedProjectId &&
+      (await this.props.loadProject({ id: selectedProjectId }));
+
     if (this.props.navigation && this.props.navigation.getParam('id'))
       selectedProjectId = parseInt(this.props.navigation.getParam('id'));
     if (this.props.selectedProject && !this.props.selectedProject.tpoData) {
@@ -154,7 +158,8 @@ const mapStateToProps = state => {
     currentUserProfile: currentUserProfileSelector(state),
     supportTreecounter: supportedTreecounterSelector(state),
     currencies: currenciesSelector(state),
-    paymentStatus: getPaymentStatus(state)
+    paymentStatus: getPaymentStatus(state),
+    selectedPlantProjectId: selectedPlantProjectIdSelector(state)
   };
 };
 
@@ -179,9 +184,10 @@ const mapDispatchToProps = dispatch => {
   );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  DonationTreesContainer
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DonationTreesContainer);
 
 DonationTreesContainer.propTypes = {
   selectedProject: PropTypes.object,


### PR DESCRIPTION
Fixes #1957

The idea is to also use the value `selectedPlantProjectId` from the redux state set at https://github.com/Plant-for-the-Planet-org/treecounter-app/blob/1e47f900a218fd6b85b13b16294054676a94d959/app/components/PublicTreeCounter/PublicTreecounter.native.js#L128 to load the project details in the `DonationTreesContainer`.