### PR TITLE
map project route to donate-tree route in web client

### DIFF
--- a/app/components/App/TreeCounter.js
+++ b/app/components/App/TreeCounter.js
@@ -17,9 +17,9 @@ import Footer from '../Footer';
 const SelectPlantProjectContainer = lazy(() =>
   import('../../containers/SelectPlantProject')
 );
-const SelectedPlantProjectContainer = lazy(() =>
-  import('./../../containers/SelectedPlantProject')
-);
+//const SelectedPlantProjectContainer = lazy(() =>
+//  import('./../../containers/SelectedPlantProject')
+//);
 const GiftTreesContainer = lazy(() => import('../../containers/GiftTrees'));
 const TargetContainer = lazy(() => import('../../containers/TargetContainer'));
 const RegisterTreesContainer = lazy(() =>

--- a/app/components/App/TreeCounter.js
+++ b/app/components/App/TreeCounter.js
@@ -347,8 +347,11 @@ class TreeCounter extends Component {
               component={SelectPlantProjectContainer}
             />
             <Route
+              // path={getLocalRoute('app_selectedProject') + '/:projectSlug?'}
+              // component={SelectedPlantProjectContainer}
+              // temporarily redirect this request to /donate-trees/:id
               path={getLocalRoute('app_selectedProject') + '/:projectSlug?'}
-              component={SelectedPlantProjectContainer}
+              component={DonationTreesContainer}
             />
             <Route
               path={getLocalRoute('app_competition') + '/:id?'}

--- a/app/components/PlantProjects/PlantProjectFull.native.js
+++ b/app/components/PlantProjects/PlantProjectFull.native.js
@@ -136,7 +136,7 @@ class PlantProjectFull extends React.Component {
             context.scheme +
             '://' +
             context.host +
-            getLocalRoute('app_donateTrees') +
+            getLocalRoute('app_selectedProject') +
             '/' +
             this.props.plantProject.id
           }

--- a/app/components/PlantProjects/PlantProjectFull.native.js
+++ b/app/components/PlantProjects/PlantProjectFull.native.js
@@ -136,7 +136,7 @@ class PlantProjectFull extends React.Component {
             context.scheme +
             '://' +
             context.host +
-            getLocalRoute('app_selectedProject') +
+            getLocalRoute('app_donateTrees') +
             '/' +
             this.props.plantProject.id
           }

--- a/app/containers/DonateTrees/index.js
+++ b/app/containers/DonateTrees/index.js
@@ -75,6 +75,11 @@ class DonationTreesContainer extends PureComponent {
   async componentDidMount() {
     let selectedProjectId = undefined;
     if (this.props.match) {
+      // patch to map a given projectSlug parameter to the id parameter
+      if (!this.props.match.params.id) {
+        this.props.match.params.id = this.props.match.params.projectSlug
+      }
+      // end patch
       selectedProjectId = parseInt(this.props.match.params.id);
     } else {
       selectedProjectId = this.props.selectedPlantProjectId;

--- a/app/containers/DonateTrees/index.js
+++ b/app/containers/DonateTrees/index.js
@@ -125,6 +125,11 @@ class DonationTreesContainer extends PureComponent {
 
   render() {
     if (this.props.match) {
+      // patch to map a given projectSlug parameter to the id parameter
+      if (!this.props.match.params.id) {
+        this.props.match.params.id = this.props.match.params.projectSlug
+      }
+      // end patch
       const {
         params: { id }
       } = this.props.match;


### PR DESCRIPTION
also patches the DonateTreeContainer to support projectSlug as parameter instead of id

Fixes #2059

@sagararyal please check if this works, e.g. with /project/1 or /project/49 - it's some ugly patch I don't like. Hopefully it does not break anything else :-(


- A first alternative solution to this patch would be a rewrite rule in the web server to change `/project/*` to `/donate-trees/*` - but that only works with a webserver, so you cannot test it locally.

- A second alternate solution would be to use a different route for the share link, e.g. /donate-trees/1 which isn't yet supported in the native apps by changing the line https://github.com/Plant-for-the-Planet-org/treecounter-app/blob/394e9d405d0d7d493e625967b586a419a8e67df2/app/components/PlantProjects/PlantProjectFull.native.js#L139  to ```getLocalRoute('app_donateTrees') +```