### PR TITLE
retrieve WebMapIds from config API call and remove from env

### DIFF
--- a/.env.deploy
+++ b/.env.deploy
@@ -6,7 +6,6 @@ api_url=${api_url}
 base=${base}
 debug=${debug}
 currency=${currency}
-mapIdsInventory=${mapIdsInventory}
 bugsnagApiKey=${bugsnagApiKey}
 androidAppId=${androidAppId}
 iosAppId=${iosAppId}

--- a/.env.develop.sample
+++ b/.env.develop.sample
@@ -11,7 +11,6 @@ base=
 # local console debugging switch
 debug=true
 currency=EUR
-mapIdsInventory=dee6acf9de774fe6878813f707b4ab88
 bugsnagApiKey=
 androidAppId=org.pftp
 iosAppId=1444740626

--- a/.env.fixtures.sample
+++ b/.env.fixtures.sample
@@ -11,7 +11,6 @@ base=
 # local console debugging switch
 debug=true
 currency=EUR
-mapIdsInventory=dee6acf9de774fe6878813f707b4ab88
 bugsnagApiKey=
 androidAppId=org.pftp
 iosAppId=1444740626

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -11,7 +11,6 @@ base=
 # local console debugging switch
 debug=
 currency=EUR
-mapIdsInventory=534da741b327459eb117f4cc93acd98e
 bugsnagApiKey=
 androidAppId=org.pftp
 iosAppId=1444740626

--- a/.env.staging.sample
+++ b/.env.staging.sample
@@ -11,7 +11,6 @@ base=
 # local console debugging switch
 debug=true
 currency=EUR
-mapIdsInventory=dee6acf9de774fe6878813f707b4ab88
 bugsnagApiKey=
 androidAppId=org.pftp
 iosAppId=1444740626

--- a/app/actions/apiRouting.js
+++ b/app/actions/apiRouting.js
@@ -2,7 +2,7 @@ const routes = require('../server/routes/fos_js_routes.json');
 import Routing from './router.min.js';
 import { debug } from '../debug';
 import { context } from '../config';
-import { getCdnMediaUrl } from './fetchConfig';
+import { getCdnMediaUrl, getWebMapIds } from './fetchConfig';
 import { getLocaleAsync } from './getLocale';
 Routing.setRoutingData(routes);
 
@@ -43,4 +43,8 @@ export const getCountryFlagImageUrl = (countryCode, type, size) => {
   return `${
     getCdnMediaUrl().images
   }/flags/${type}/${size}/${countryCode}.${type}`;
+};
+
+export const getWebMapId = type => {
+  return getWebMapIds()[type];
 };

--- a/app/actions/fetchConfig.js
+++ b/app/actions/fetchConfig.js
@@ -11,14 +11,16 @@ import { setCurrencyAction } from './globalCurrency';
 // import { setCdnMedia } from '../reducers/configReducer';
 let cdnMedia = {};
 let currency = '';
+let webMapIds = {};
+
 export function fetchLocation() {
   return dispatch => {
     if (!getItemSync('preferredCurrency')) {
       getRequest('public_ipstack')
-        .then(data => {
-          // debug('Got location fetch ip', data);
+        .then(res => {
+          // debug('Got location fetch ip', res.data);
           const foundLocation = find(countryCodes, {
-            countryCode: data.data.country_code
+            countryCode: res.data.country_code
           });
           supportedCurrency.includes(foundLocation.code) &&
             dispatch(setCurrencyAction(foundLocation.code));
@@ -38,22 +40,28 @@ export function getCurrency() {
 export function getCdnMediaUrl() {
   return cdnMedia;
 }
+
+export function getWebMapIds() {
+  return webMapIds;
+}
+
 export function fetchConfig() {
   return dispatch => {
     // if (!getItemSync('preferredCurrency')) {
     getRequest('config_get')
-      .then(data => {
-        debug('Got config fetch data:', data.data);
-        cdnMedia = data.data.cdnMedia;
+      .then(res => {
+        debug('Got config fetch data:', res.data);
+        cdnMedia = res.data.cdnMedia;
+        webMapIds = res.data.webMapIds;
 
         // fake data manipulation for debug purpose, please remove this when debug finishes
         // data.data.currency = 'USD';
         // debug code ends
 
-        if (data.data && data.data.currency) {
-          currency = data.data.currency;
-          supportedCurrency.includes(data.data.currency) &&
-            dispatch(setCurrencyAction(data.data.currency));
+        if (res.data && res.data.currency) {
+          currency = res.data.currency;
+          supportedCurrency.includes(res.data.currency) &&
+            dispatch(setCurrencyAction(res.data.currency));
         } else {
           dispatch(fetchLocation());
         }

--- a/app/components/Map/ArcGISContributionCaptureMap.js
+++ b/app/components/Map/ArcGISContributionCaptureMap.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { debug } from '../../debug';
 import MapContributionCapture from './MapContributionCapture';
-import { context } from '../../config';
+import { getWebMapId } from '../../actions/apiRouting';
 
 const ArcGISContributionCaptureMap = ({ geoLocation, onLocationSelected }) => {
-  const webMapId = context.mapIds.inventory;
+  const webMapId = getWebMapId('inventory');
   debug('ArcGISContributionCaptureMap: webMapId', webMapId);
   debug('ArcGISContributionCaptureMap: geoLocation', geoLocation);
   return (

--- a/app/components/Map/ArcGISContributionsMap.js
+++ b/app/components/Map/ArcGISContributionsMap.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { debug } from '../../debug';
 import MapContributions from './MapContributions';
-import { context } from '../../config';
+import { getWebMapId } from '../../actions/apiRouting';
 
 const ArcGISContributionsMap = ({ userId }) => {
-  const webMapId = context.mapIds.inventory;
+  const webMapId = getWebMapId('inventory');
   debug('ArcGISContributionsMap: webMapId', webMapId);
   debug('ArcGISContributionsMap: userId', userId);
   return (

--- a/app/components/PublicTreeCounter/UserFootprint.js
+++ b/app/components/PublicTreeCounter/UserFootprint.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getWebMapId } from '../../actions/apiRouting';
 import UserSynopsis from '../Common/UserSynopsis';
 import UserHomepageLink from '../Common/UserHomepageLink';
 import ArcGISContributionsMap from '../Map/ArcGISContributionsMap';

--- a/app/components/PublicTreeCounter/UserFootprint.js
+++ b/app/components/PublicTreeCounter/UserFootprint.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { getWebMapId } from '../../actions/apiRouting';
 import UserSynopsis from '../Common/UserSynopsis';
 import UserHomepageLink from '../Common/UserHomepageLink';
 import ArcGISContributionsMap from '../Map/ArcGISContributionsMap';
@@ -22,7 +22,7 @@ const UserFootprint = ({ userProfile }) => {
         caption={userProfile.linkText}
       />
       <ArcGISContributionsMap
-        webMapId={'d601683709dc415b99ddc1bc66a6d8eb'}
+        webMapId={getWebMapId('inventory')}
         userId={userProfile.id}
       />
       {/*<UserBarChart contributions={userProfile.contributions} />*/}

--- a/app/components/PublicTreeCounter/UserFootprint.js
+++ b/app/components/PublicTreeCounter/UserFootprint.js
@@ -5,11 +5,6 @@ import UserSynopsis from '../Common/UserSynopsis';
 import UserHomepageLink from '../Common/UserHomepageLink';
 import ArcGISContributionsMap from '../Map/ArcGISContributionsMap';
 
-/**
- * MapIds:
- *   - d601683709dc415b99ddc1bc66a6d8eb
- *   - 534da741b327459eb117f4cc93acd98e
- */
 const UserFootprint = ({ userProfile }) => {
   return (
     <div className="full_width">
@@ -21,10 +16,7 @@ const UserFootprint = ({ userProfile }) => {
         homepageUrl={userProfile.url}
         caption={userProfile.linkText}
       />
-      <ArcGISContributionsMap
-        webMapId={getWebMapId('inventory')}
-        userId={userProfile.id}
-      />
+      <ArcGISContributionsMap userId={userProfile.id} />
       {/*<UserBarChart contributions={userProfile.contributions} />*/}
     </div>
   );

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -12,7 +12,6 @@ export const context = {
   base: process.env.base, // API base url. Debug mode off: "" on: "/app_dev.php" (requires login)
   debug: process.env.debug, // local console debugging switch
   currency: process.env.currency,
-  mapIds: { inventory: process.env.mapIdsInventory },
   bugsnagApiKey: process.env.bugsnagApiKey,
   android: {
     appId: process.env.androidAppId

--- a/app/config/index.native.js
+++ b/app/config/index.native.js
@@ -12,7 +12,6 @@ export const context = {
   base: config.base, // API base url. Debug mode off: "" on: "/app_dev.php" (requires login)
   debug: config.debug, // local console debugging switch
   currency: config.currency,
-  mapIds: { inventory: config.mapIdsInventory },
   bugsnagApiKey: config.bugsnagApiKey,
   android: {
     appId: config.androidAppId

--- a/app/containers/Leaderboard/index.js
+++ b/app/containers/Leaderboard/index.js
@@ -6,6 +6,7 @@ import {
   ExploreDataAction,
   LeaderBoardDataAction
 } from '../../actions/exploreAction';
+import { getWebMapIds } from '../../actions/fetchConfig';
 import { updateRoute, replaceRoute } from '../../helpers/routerHelper';
 import i18n from '../../locales/i18n';
 import { objectToQueryParams, queryParamsToObject } from '../../helpers/utils';
@@ -220,7 +221,9 @@ class LeaderBoardContainer extends React.Component {
             mapInfo.mapLayersKeys = Object.keys(mapInfo.mapLayers);
           }
           if (exploreData.webMapIds) {
-            mapInfo.webMapIds = exploreData.webMapIds;
+            // webMapIds now retrieved from config instead explore API call
+            mapInfo.webMapIds = getWebMapIds();
+            // mapInfo.webMapIds = exploreData.webMapIds;
           }
         }
 

--- a/app/reducers/configReducer.js
+++ b/app/reducers/configReducer.js
@@ -1,10 +1,14 @@
 import isEqual from 'lodash/isEqual';
 import { createAction, handleActions } from 'redux-actions';
+
 export const setCdnMedia = createAction('CDNMEDIA_SET');
 export const getCdnMedia = state => state.cdnMedia;
+export const setWebMapIdList = createAction('WEBMAPIDS_SET');
+export const getWebMapIdList = state => state.webMapIds;
 
 export const initialState = {
-  cdnMedia: {}
+  cdnMedia: {},
+  webMapIds: {}
 };
 
 const configReducer = handleActions(
@@ -12,6 +16,11 @@ const configReducer = handleActions(
     [setCdnMedia]: (state, action) => ({
       cdnMedia: isEqual(state.cdnMedia, action.payload)
         ? state.cdnMedia
+        : action.payload
+    }),
+    [setWebMapIdList]: (state, action) => ({
+      webMapIds: isEqual(state.webMapIds, action.payload)
+        ? state.webMapIds
         : action.payload
     })
   },

--- a/app/selectors/index.js
+++ b/app/selectors/index.js
@@ -25,7 +25,7 @@ import { getPledgeEvents } from '../reducers/pledgeEventReducer';
 import { getPaymentStatus } from '../reducers/paymentStatus';
 import { getCurrencies } from '../reducers/currenciesReducer';
 import { getGlobalCurrency } from '../reducers/currencyReducer';
-import { getCdnMedia } from '../reducers/configReducer';
+import { getCdnMedia, getWebMapIdList } from '../reducers/configReducer';
 import { getCompetitionDetail } from '../reducers/competitionDetailReducer';
 
 export const supportedTreecounterSelector = state =>
@@ -48,6 +48,7 @@ export const postedPledgesSelector = state => getPostedPledges(state);
 export const currenciesSelector = state => getCurrencies(state);
 export const getCurrency = state => getGlobalCurrency(state);
 export const getCdnMediaUrl = state => getCdnMedia(state);
+export const getWebMapIds = state => getWebMapIdList(state);
 export const paymentStatusSelector = state => getPaymentStatus(state);
 export const pledgeEventSelector = state => getPledgeEvents(state);
 export const selectedCompetitionIdSelector = state =>


### PR DESCRIPTION
This change retrieve all the ERSI WebMapIds from the backend, so it's not necessary any more to configure them in the client and always get the right ids for the used backend.

Changes:
- retrieve WebMapIds from config API call instead from environment or explore API call
- using redux to store the values in work in progress and not yet used (same of for CDN urls)

After this PR got merged, I will remove mapIdsInventory from every build system (CircleCI, GitHub actions, buddy.works et al).