### PR TITLE
fixed wrong route in web client for accepting a challenge

### DIFF
--- a/app/components/App/TreeCounter.js
+++ b/app/components/App/TreeCounter.js
@@ -270,7 +270,7 @@ class TreeCounter extends Component {
             />
             <PrivateRoute
               path={
-                getLocalRoute('app_challengeResponse') + '/active' + '/:token'
+                getLocalRoute('app_challengeResponse') + '/accept' + '/:token'
               }
               component={RedirectedPrivateAcceptEmail}
             />

--- a/app/components/Challenge/RedirectedPrivateAcceptEmail.js
+++ b/app/components/Challenge/RedirectedPrivateAcceptEmail.js
@@ -17,6 +17,7 @@ export default class RedirectedPrivateAcceptEmail extends Component {
   UNSAFE_componentWillMount() {
     this.props.acceptChallenge();
   }
+
   render() {
     return (
       <div className="app-container__content--center sidenav-wrapper">

--- a/app/containers/Challenge/RedirectedPrivateAcceptEmail.js
+++ b/app/containers/Challenge/RedirectedPrivateAcceptEmail.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
 import { acceptChallenge } from '../../actions/challengeActions';
-import RedirectedPrivateAcceptEmail from '../../components/Challenge/RedirectedPublicDenyEmail';
+import RedirectedPrivateAcceptEmail from '../../components/Challenge/RedirectedPrivateAcceptEmail';
 
 class RedirectedPrivateAcceptEmailContainer extends React.Component {
   render() {


### PR DESCRIPTION
Fixes #1873

Changes in this pull request:
- The route to accept a challenge was expecting `active` instead `accept` as written in the email links. I fixed this and also fixed the wrong import of the related component.
- I have not fixed not showing the right error message from the API call if opening the link more than once.