### PR TITLE
refactored refresh_token functionality

### DIFF
--- a/app/stores/localStorage.native.js
+++ b/app/stores/localStorage.native.js
@@ -61,6 +61,6 @@ export const getItemSync = async key => {
 export const clearStorage = async () => {
   //const welcomeKey = await fetchItem('welcome').catch(error => debug(error));
   //debug(welcomeKey);
-  await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove);
+  await AsyncStorage.clear();
   //saveItem('welcome', welcomeKey);
 };

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -56,7 +56,7 @@ const refreshTokenIfExpired = async () => {
       if (response.data) {
         const newToken = response.data.token;
         // refresh_token does not seem to be part of the result of api/token/refresh any more
-        const refreshToken = response.data.refresh_token || prev_refresh_token;
+        const refreshToken = response.data.refresh_token || prev_refresh_token;
         updateJWT(newToken, refreshToken);
         return newToken;
       }

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -48,7 +48,6 @@ const getExpirationTimeStamp = token => {
 const refreshTokenIfExpired = async () => {
   if (await tokenIsExpired()) {
     const prev_refresh_token = await getItem('refresh_token');
-    console.log('prev_refresh_token', prev_refresh_token);
     if (prev_refresh_token) {
       let response = await postRequest('gesdinet_jwt_refresh_token', {
         refresh_token: prev_refresh_token

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -1,6 +1,6 @@
 import jwtDecode from 'jwt-decode';
 import { debug } from '../debug';
-import { fetchItem, getItem, saveItem } from '../stores/localStorage';
+import { getItem, saveItem } from '../stores/localStorage';
 import { postRequest } from './api';
 
 /**
@@ -47,18 +47,22 @@ const getExpirationTimeStamp = token => {
  */
 const refreshTokenIfExpired = async () => {
   if (await tokenIsExpired()) {
-    const prev_refresh_token = await fetchItem('refresh_token').catch(error => debug(error));
-    let response = await postRequest('gesdinet_jwt_refresh_token', {
-      refresh_token: prev_refresh_token
-    });
-
-    const newToken = response.data.token;
-    const refreshToken = response.data.refresh_token;
-    updateJWT(newToken, refreshToken);
-    return newToken;
-  } else {
-    return;
+    const prev_refresh_token = await getItem('refresh_token');
+    console.log('prev_refresh_token', prev_refresh_token);
+    if (prev_refresh_token) {
+      let response = await postRequest('gesdinet_jwt_refresh_token', {
+        refresh_token: prev_refresh_token
+      });
+      if (response.data) {
+        const newToken = response.data.token;
+        // refresh_token does not seem to be part of the result of api/token/refresh any more
+        const refreshToken = response.data.refresh_token || prev_refresh_token;
+        updateJWT(newToken, refreshToken);
+        return newToken;
+      }
+    }
   }
+  return;
 };
 
 const tokenIsExpired = async () => {
@@ -68,8 +72,12 @@ const tokenIsExpired = async () => {
 };
 
 const getTokenExpires = async () => {
-  let tokenExpiryTime = await fetchItem('token_expires').catch(error => debug(error));
-  return parseInt(tokenExpiryTime);
+  let tokenExpiryTime = await getItem('token_expires');
+  if (tokenExpiryTime) {
+    return parseInt(tokenExpiryTime);
+  } else {
+    return 0;
+  }
 };
 
 const getCurrentUnixTimestamp = () => Math.floor(Date.now() / 1000);


### PR DESCRIPTION
Fixes #2083
Related to #1611

Changes in this pull request:
- keep old `refresh_token` if not new `refresh_token` is returned by API call
- replaced `fetchItem` with `getItem`
- added more safety checks
