### PR TITLE
added update screen, wait for loading of config API call

### DIFF
--- a/app/actions/fetchConfig.js
+++ b/app/actions/fetchConfig.js
@@ -9,28 +9,28 @@ import supportedCurrency from '../assets/supportedCurrency.json';
 import { find } from 'lodash';
 import { setCurrencyAction } from './globalCurrency';
 // import { setCdnMedia } from '../reducers/configReducer';
+
 let cdnMedia = {};
 let currency = '';
 let webMapIds = {};
+let appVersions = {};
 
-export function fetchLocation() {
-  return dispatch => {
-    if (!getItemSync('preferredCurrency')) {
-      getRequest('public_ipstack')
-        .then(res => {
-          // debug('Got location fetch ip', res.data);
-          const foundLocation = find(countryCodes, {
-            countryCode: res.data.country_code
-          });
-          supportedCurrency.includes(foundLocation.code) &&
-            dispatch(setCurrencyAction(foundLocation.code));
-        })
-
-        .catch(error => {
-          console.error(error);
+export async function fetchLocation() {
+  if (!getItemSync('preferredCurrency')) {
+    getRequest('public_ipstack')
+      .then(res => {
+        debug('Got location fetch ip', res.data);
+        const foundLocation = find(countryCodes, {
+          countryCode: res.data.country_code
         });
-    }
-  };
+        supportedCurrency.includes(foundLocation.code) &&
+          setCurrencyAction(foundLocation.code);
+      })
+
+      .catch(error => {
+        console.error(error);
+      });
+  }
 }
 
 export function getCurrency() {
@@ -45,33 +45,39 @@ export function getWebMapIds() {
   return webMapIds;
 }
 
-export function fetchConfig() {
-  return dispatch => {
-    // if (!getItemSync('preferredCurrency')) {
-    getRequest('config_get')
-      .then(res => {
-        debug('Got config fetch data:', res.data);
-        cdnMedia = res.data.cdnMedia;
-        webMapIds = res.data.webMapIds;
+export function getAppVersions() {
+  return appVersions;
+}
 
-        // fake data manipulation for debug purpose, please remove this when debug finishes
-        // data.data.currency = 'USD';
-        // debug code ends
+export async function fetchConfig() {
+  // if (!getItemSync('preferredCurrency')) {
+  await getRequest('config_get')
+    .then(res => {
+      debug('Got config fetch data:', res.data);
+      cdnMedia = res.data.cdnMedia;
+      webMapIds = res.data.webMapIds;
+      appVersions = res.data.appVersions;
+      // Test outdates app addding these values:
+      // appVersions.ios[0]='1.3.5';
+      // appVersions.android[0]='1.3.5';
 
-        if (res.data && res.data.currency) {
-          currency = res.data.currency;
-          supportedCurrency.includes(res.data.currency) &&
-            dispatch(setCurrencyAction(res.data.currency));
-        } else {
-          dispatch(fetchLocation());
-        }
-        // for now we are not storing those in redux, please uncomment this when you need these urls in your components
-        // dispatch(setCdnMedia(data.data.cdnMedia));
-      })
+      // fake data manipulation for debug purpose, please remove this when debug finishes
+      // data.data.currency = 'USD';
+      // debug code ends
 
-      .catch(error => {
-        console.error(error);
-      });
-    // }
-  };
+      if (res.data && res.data.currency) {
+        currency = res.data.currency;
+        supportedCurrency.includes(res.data.currency) &&
+          setCurrencyAction(res.data.currency);
+      } else {
+        fetchLocation();
+      }
+      // for now we are not storing those in redux, please uncomment this when you need these urls in your components
+      // setCdnMedia(data.data.cdnMedia);
+    })
+
+    .catch(error => {
+      console.error(error);
+    });
+  // }
 }

--- a/app/actions/fetchConfig.js
+++ b/app/actions/fetchConfig.js
@@ -65,8 +65,8 @@ export function fetchConfig() {
           webMapIds = res.data.webMapIds;
           appVersions = res.data.appVersions;
           // Test outdates app addding these values:
-          //appVersions.ios[0]='1.3.5';
-          //appVersions.android[0]='1.3.5';
+          //appVersions.ios='1.3.5';
+          //appVersions.android='1.3.5';
 
           // fake data manipulation for debug purpose, please remove this when debug finishes
           // data.data.currency = 'USD';

--- a/app/actions/fetchConfig.js
+++ b/app/actions/fetchConfig.js
@@ -77,7 +77,8 @@ export function fetchConfig() {
             supportedCurrency.includes(res.data.currency) &&
               dispatch(setCurrencyAction(res.data.currency));
           } else {
-            dispatch(fetchLocation());
+            //disabled fallback with ipstack
+            // dispatch(fetchLocation());
           }
           // for now we are not storing those in redux, please uncomment this when you need these urls in your components
           // dispatch(setCdnMedia(data.data.cdnMedia));

--- a/app/components/App/TreeCounter.js
+++ b/app/components/App/TreeCounter.js
@@ -137,8 +137,8 @@ class TreeCounter extends Component {
       isCancelled: false
     };
     initLocale();
-    fetchConfig();
     this.props.fetchCurrencies();
+    this.props.fetchConfig();
   }
 
   _appRoutes = undefined;
@@ -436,6 +436,7 @@ const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
       fetchCurrencies,
+      fetchConfig,
       loadUserProfile,
       NotificationAction,
       fetchpledgeEventsAction

--- a/app/components/App/TreeCounter.js
+++ b/app/components/App/TreeCounter.js
@@ -137,8 +137,8 @@ class TreeCounter extends Component {
       isCancelled: false
     };
     initLocale();
+    fetchConfig();
     this.props.fetchCurrencies();
-    this.props.fetchConfig();
   }
 
   _appRoutes = undefined;
@@ -436,7 +436,6 @@ const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
       fetchCurrencies,
-      fetchConfig,
       loadUserProfile,
       NotificationAction,
       fetchpledgeEventsAction

--- a/app/components/App/TreeCounter.native.js
+++ b/app/components/App/TreeCounter.native.js
@@ -12,7 +12,6 @@ import SafeAreaView from 'react-native-safe-area-view';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { initLocale } from '../../actions/getLocale.native.js';
 import { fetchCurrencies } from '../../actions/currencies';
-import { fetchConfig } from '../../actions/fetchConfig';
 
 class App extends Component {
   componentDidMount() {

--- a/app/components/App/TreeCounter.native.js
+++ b/app/components/App/TreeCounter.native.js
@@ -13,11 +13,12 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { initLocale } from '../../actions/getLocale.native.js';
 import { fetchCurrencies } from '../../actions/currencies';
 import { fetchConfig } from '../../actions/fetchConfig';
+
 class App extends Component {
   componentDidMount() {
     initLocale();
+    // moved fetchConfig to Menu component
     this.props.fetchCurrencies();
-    this.props.fetchConfig();
     // TODO: at this time the locale isn't yet defined, so this API call is currently done with locale = undefined
     // Is there any way to wait with this API call until the locale is defined?
   }
@@ -44,7 +45,6 @@ const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
       fetchCurrencies,
-      fetchConfig
       // loadUserProfile,
       // NotificationAction,
     },

--- a/app/components/Menu/index.js
+++ b/app/components/Menu/index.js
@@ -289,7 +289,7 @@ class Menu extends Component {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={`https://play.google.com/store/apps/details?id=${context['android'].appId}`}
+            href={`https://play.app.goo.gl/?link=https://play.google.com/store/apps/details?id=${context['android'].appId}`}
           >
             <img src={images['googlePlayBadge_' + userLang.replace(/-/g,'')]} />
           </a>

--- a/app/components/Menu/index.native.js
+++ b/app/components/Menu/index.native.js
@@ -59,8 +59,7 @@ class Menu extends Component {
     // check for updates
     await this.props.fetchConfig();
     console.log('package version:', version, ' appVersions:', getAppVersions());
-    if (getAppVersions()[Platform.OS] && getAppVersions()[Platform.OS][0] && version < getAppVersions()[Platform.OS][0]) {
-    // if (getAppVersions()[Platform.OS] && getAppVersions()[Platform.OS][0] && version < getAppVersions()[Platform.OS][0]) {
+    if (getAppVersions()[Platform.OS] && version < getAppVersions()[Platform.OS]) {
        // show the user an information that the app is outdate and a link to the app stores
       updateStaticRoute('app_splash_screen', this.props.navigation);
     } else {

--- a/app/components/Menu/index.native.js
+++ b/app/components/Menu/index.native.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { View, ScrollView, SafeAreaView, Text, Linking, Platform } from 'react-native';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { debug } from '../../debug';
 import styles from '../../styles/menu.native';
 import { updateRoute, updateStaticRoute } from '../../helpers/routerHelper';
@@ -20,18 +22,14 @@ import { version } from './../../../package.json';
 
 //   icons.target_outline;
 
-export default class Menu extends Component {
-  state = {
-    showCurrencyModal: false
-  };
-  static propTypes = {
-    menuData: PropTypes.array.isRequired,
-    onPress: PropTypes.func,
-    selectPlantProjectAction: PropTypes.func,
-    userProfile: PropTypes.any,
-    navigation: PropTypes.any,
-    lastRoute: PropTypes.any
-  };
+class Menu extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showCurrencyModal: false
+    };
+  }
+
   hideCurrencyModal = () => {
     this.setState({ showCurrencyModal: false });
   };
@@ -59,7 +57,7 @@ export default class Menu extends Component {
     Linking.addEventListener('url', this.appWokeUp);
 
     // check for updates
-    await fetchConfig();
+    await this.props.fetchConfig();
     console.log('package version:', version, ' appVersions:', getAppVersions());
     if (getAppVersions()[Platform.OS] && getAppVersions()[Platform.OS][0] && version < getAppVersions()[Platform.OS][0]) {
     // if (getAppVersions()[Platform.OS] && getAppVersions()[Platform.OS][0] && version < getAppVersions()[Platform.OS][0]) {
@@ -364,3 +362,20 @@ export default class Menu extends Component {
     );
   }
 }
+
+const mapDispatchToProps = dispatch => {
+  return bindActionCreators(
+    {
+      fetchConfig
+    },
+    dispatch);
+};
+export default connect(null, mapDispatchToProps)(Menu);
+Menu.propTypes = {
+  menuData: PropTypes.array.isRequired,
+  onPress: PropTypes.func,
+  selectPlantProjectAction: PropTypes.func,
+  userProfile: PropTypes.any,
+  navigation: PropTypes.any,
+  lastRoute: PropTypes.any
+};

--- a/app/components/Menu/index.native.js
+++ b/app/components/Menu/index.native.js
@@ -57,21 +57,22 @@ class Menu extends Component {
     Linking.addEventListener('url', this.appWokeUp);
 
     // check for updates
-    await this.props.fetchConfig();
-    console.log('package version:', version, ' appVersions:', getAppVersions());
-    if (getAppVersions()[Platform.OS] && version < getAppVersions()[Platform.OS]) {
-       // show the user an information that the app is outdate and a link to the app stores
-      updateStaticRoute('app_splash_screen', this.props.navigation);
-    } else {
-      // const welcome = await fetchItem('welcome').catch(error => debug(error));
-      if (!this.props.userProfile) {
-        // if (welcome == null) {
-        //   updateRoute('welcome_screen', this.props.navigation, 0);
-        // } else {
-        //   updateRoute('app_homepage', this.props.navigation, 0);
-        // }
-        updateRoute('welcome_screen', this.props.navigation, 0);
-      }
+    this.props.fetchConfig().then(() => {
+      console.log('package version:', version, ' appVersions:', getAppVersions());
+      if (getAppVersions()[Platform.OS] && version < getAppVersions()[Platform.OS]) {
+         // show the user an information that the app is outdate and a link to the app stores
+        updateStaticRoute('app_splash_screen', this.props.navigation);
+      }}
+    );
+
+    // const welcome = await fetchItem('welcome').catch(error => debug(error));
+    if (!this.props.userProfile) {
+      // if (welcome == null) {
+      //   updateRoute('welcome_screen', this.props.navigation, 0);
+      // } else {
+      //   updateRoute('app_homepage', this.props.navigation, 0);
+      // }
+      updateRoute('welcome_screen', this.props.navigation, 0);
     }
 
     // saveItem('welcome', JSON.stringify({ value: 'true' }));

--- a/app/components/Menu/index.native.js
+++ b/app/components/Menu/index.native.js
@@ -15,6 +15,8 @@ import UserProfileImage from '../Common/UserProfileImage.native';
 import { LargeMenuItem } from './MenuItem.native';
 import countryCodes from '../../assets/countryCodes.json';
 import CurrencySelector from '../Common/CurrencySelectorList.native';
+import { fetchConfig, getAppVersions } from '../../actions/fetchConfig';
+import { version } from './../../../package.json';
 
 //   icons.target_outline;
 
@@ -55,15 +57,26 @@ export default class Menu extends Component {
 
     // This listener handles the case where the app is woken up from the Universal or Deep Linking
     Linking.addEventListener('url', this.appWokeUp);
-    // const welcome = await fetchItem('welcome').catch(error => debug(error));
-    if (!this.props.userProfile) {
-      // if (welcome == null) {
-      //   updateRoute('welcome_screen', this.props.navigation, 0);
-      // } else {
-      //   updateRoute('app_homepage', this.props.navigation, 0);
-      // }
-      updateRoute('welcome_screen', this.props.navigation, 0);
+
+    // check for updates
+    await fetchConfig();
+    console.log('package version:', version, ' appVersions:', getAppVersions());
+    if (getAppVersions()[Platform.OS] && getAppVersions()[Platform.OS][0] && version < getAppVersions()[Platform.OS][0]) {
+    // if (getAppVersions()[Platform.OS] && getAppVersions()[Platform.OS][0] && version < getAppVersions()[Platform.OS][0]) {
+       // show the user an information that the app is outdate and a link to the app stores
+      updateStaticRoute('app_splash_screen', this.props.navigation);
+    } else {
+      // const welcome = await fetchItem('welcome').catch(error => debug(error));
+      if (!this.props.userProfile) {
+        // if (welcome == null) {
+        //   updateRoute('welcome_screen', this.props.navigation, 0);
+        // } else {
+        //   updateRoute('app_homepage', this.props.navigation, 0);
+        // }
+        updateRoute('welcome_screen', this.props.navigation, 0);
+      }
     }
+
     // saveItem('welcome', JSON.stringify({ value: 'true' }));
   }
   componentWillUnmount() {

--- a/app/components/Menu/index.native.js
+++ b/app/components/Menu/index.native.js
@@ -45,7 +45,7 @@ class Menu extends Component {
     }
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     if (Platform.OS === 'android') {
       const NativeLinking = require('react-native/Libraries/Linking/NativeLinking').default;
       NativeLinking.getInitialURL().then(url => url && this.resetStackToProperRoute(url)).catch(e => debug(e));

--- a/app/components/Navigators/AppDrawerNavigator.js
+++ b/app/components/Navigators/AppDrawerNavigator.js
@@ -62,8 +62,9 @@ import IndividualsLeaderBoard from '../LeaderboardRefresh/Individuals/Individual
 import tpoLeaderBoard from '../LeaderboardRefresh/TPOs/tpoLeaderBoard';
 import RegisterTreesContainer from '../../containers/RegisterTrees';
 import colors from '../../utils/constants';
-
 import FullMapComponent from './../UserHome/FullMapComponent';
+import SplashScreen from './../TreecounterGraphics/SplashScreen';
+
 const headerLabels = {
   [getLocalRoute('app_login')]: 'label.login',
   [getLocalRoute('app_signup')]: 'label.signUp',
@@ -101,7 +102,8 @@ const headerLabels = {
   ['app_create_competition']: '',
   ['app_unfulfilled_pledge_events']: 'label.pledges',
   ['app_pledge_form']: 'label.pledgeToPlant',
-  ['app_pledge_update_form']: 'label.updatePledge'
+  ['app_pledge_update_form']: 'label.updatePledge',
+  ['app_splash_screen']: ''
 };
 
 export const getAppNavigator = function (isLoggedIn, userProfile) {
@@ -161,6 +163,18 @@ export const getAppNavigator = function (isLoggedIn, userProfile) {
       }
     }
   );
+
+  const splashScreenNavigator = createStackNavigator(
+    {
+      ['app_splash_screen']: {
+        screen: SplashScreen
+      }
+    },
+    {
+      headerMode: 'none'
+    }
+  );
+
   const getTitle = function (navigation) {
     let title = navigation.getParam('titleParam');
     try {
@@ -421,6 +435,7 @@ export const getAppNavigator = function (isLoggedIn, userProfile) {
 
   const AppNavigator = createDrawerNavigator(
     {
+      splashScreenNavigator,
       appStackNavigator: {
         screen: appStackNavigator,
         path: ''

--- a/app/components/TreecounterGraphics/SplashScreen.native.js
+++ b/app/components/TreecounterGraphics/SplashScreen.native.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import {
+  Text,
+  View,
+  TouchableOpacity,
+  Image,
+  Platform,
+  Linking
+} from 'react-native';
+import styles from '../../styles/splashScreen.native';
+import { planetLogo } from './../../assets';
+import { context } from '../../config';
+import i18n from '../../locales/i18n';
+
+export default class SplashScreen extends Component {
+  static navigationOptions = {
+    header: null
+  };
+  render() {
+    return (
+      <View style={styles.updateMainView}>
+        <Image source={planetLogo} style={styles.updateImage} />
+        <Text style={styles.updateTitle}>
+          {' '}
+          {i18n.t('label.updateRequired')}{' '}
+        </Text>
+        <Text style={styles.updateExplanation}> {i18n.t('label.updateExplanation')} </Text>
+
+        {Platform.OS === 'ios' ? (
+          <TouchableOpacity
+            onPress={() =>
+              Linking.openURL(`https://apps.apple.com/app/plant-for-the-planet/id${context['ios'].appId}`)
+            }
+            style={styles.updateButtonStyle}
+          >
+            <Text style={styles.updateButtonText}>
+              {i18n.t('label.openAppStore')}
+            </Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            onPress={() =>
+              Linking.openURL(
+                `https://play.app.goo.gl/?link=https://play.google.com/store/apps/details?id=${context['android'].appId}`
+              )
+            }
+            style={styles.updateButtonStyle}
+          >
+            <Text style={styles.updateButtonText}>
+              {i18n.t('label.openPlayStore')}
+            </Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  }
+}

--- a/app/locales/de/trillionLabels.json
+++ b/app/locales/de/trillionLabels.json
@@ -1,4 +1,8 @@
 {
   "world": "Welt",
-  "leaderboard": "Bestenliste"
+  "leaderboard": "Bestenliste",
+  "updateRequired": "Aktualisierung verfügbar",
+  "updateExplanation": "Wir haben neue Funktionen eingeführt. Bitte aktualisiere die App, um mehr Bäume zu pflanzen!",
+  "openAppStore": "Öffne App Store",
+  "openPlayStore": "Öffne Play Store"
 }

--- a/app/locales/en/trillionLabels.json
+++ b/app/locales/en/trillionLabels.json
@@ -1,4 +1,8 @@
 {
   "world": "World",
-  "leaderboard": "Leaderboard"
+  "leaderboard": "Leaderboard",
+  "updateRequired": "Update Required",
+  "updateExplanation": "We’ve introduced new features, please update the app to plant more trees!",
+  "openAppStore": "Open App Store",
+  "openPlayStore": "Open Play Store"
 }

--- a/app/styles/splashScreen.native.js
+++ b/app/styles/splashScreen.native.js
@@ -1,0 +1,53 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  updateMainView: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  updateTitle: {
+    fontSize: 27,
+    fontWeight: '800',
+    fontStyle: 'normal',
+    lineHeight: 40,
+    letterSpacing: 0,
+    textAlign: 'left',
+    color: '#4d5153',
+    marginTop: 54
+  },
+  updateImage: {
+    width: 150,
+    height: 150
+  },
+  updateExplanation: {
+    fontSize: 18,
+    fontWeight: '400',
+    fontStyle: 'normal',
+    lineHeight: 27,
+    letterSpacing: 0,
+    textAlign: 'center',
+    color: '#4d5153',
+    marginHorizontal: 44,
+    marginTop: 7
+  },
+  updateButtonStyle: {
+    height: 52,
+    borderRadius: 100,
+    backgroundColor: '#89b53a',
+    width: '86%',
+    justifyContent: 'center',
+    position: 'absolute',
+    bottom: '7%'
+  },
+  updateButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    fontStyle: 'normal',
+    lineHeight: 22,
+    letterSpacing: 0.21,
+    textAlign: 'center',
+    color: '#ffffff'
+  }
+});

--- a/app/styles/splashScreen.native.js
+++ b/app/styles/splashScreen.native.js
@@ -9,8 +9,7 @@ export default EStyleSheet.create({
   },
   updateTitle: {
     fontSize: 27,
-    fontWeight: '800',
-    fontStyle: 'normal',
+    fontFamily:'OpenSans-Bold',
     lineHeight: 40,
     letterSpacing: 0,
     textAlign: 'left',
@@ -23,8 +22,7 @@ export default EStyleSheet.create({
   },
   updateExplanation: {
     fontSize: 18,
-    fontWeight: '400',
-    fontStyle: 'normal',
+    fontFamily:'OpenSans-Regular',
     lineHeight: 27,
     letterSpacing: 0,
     textAlign: 'center',
@@ -43,8 +41,7 @@ export default EStyleSheet.create({
   },
   updateButtonText: {
     fontSize: 16,
-    fontWeight: '600',
-    fontStyle: 'normal',
+    fontFamily:'OpenSans-SemiBold',
     lineHeight: 22,
     letterSpacing: 0.21,
     textAlign: 'center',

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -11,8 +11,6 @@ import { context } from '../config';
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response;
-  } else if (response.status == 426) {
-    return response;
   } else {
     let error = new Error(response);
     throw error;
@@ -27,11 +25,13 @@ function onAPIError(error) {
   // if (error.response) {
   //   NotificationManager.error(error.response.data ? error.response.data.message || 'Error', 'Error', 5000);
   // }
+  // Unauthorized error shall logout users
   if (error.response && error.response.status === 401) {
     getStore().dispatch(logoutUser());
   }
+  // Upgrade error shall logout users
   if (error.response && error.response.status === 426) {
-    // TODO show update message
+    getStore().dispatch(logoutUser());
   }
   throw error;
 }

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -11,6 +11,8 @@ import { context } from '../config';
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response;
+  } else if (response.status == 426) {
+    return response;
   } else {
     let error = new Error(response);
     throw error;
@@ -27,6 +29,9 @@ function onAPIError(error) {
   // }
   if (error.response && error.response.status === 401) {
     getStore().dispatch(logoutUser());
+  }
+  if (error.response && error.response.status === 426) {
+    // TODO show update message
   }
   throw error;
 }


### PR DESCRIPTION
Fixes #2370

Changes in this pull request:
- added update screen from #1376
- wait for loading of config API call in native app (to check outdated app versions)
- increase config API call version to v1.2 (so we can return HTTP status 426 for v1.1 in the future)
- ignore HTTP status 426 API responses

@jmiridis this PR requires backend changes to become active.