### PR TITLE
check if the API response contains valid data object

### DIFF
--- a/app/actions/apiRouting.js
+++ b/app/actions/apiRouting.js
@@ -1,6 +1,6 @@
 const routes = require('../server/routes/fos_js_routes.json');
 import Routing from './router.min.js';
-import { debug } from '../debug';
+//import { debug } from '../debug';
 import { context } from '../config';
 import { getCdnMediaUrl, getWebMapIds } from './fetchConfig';
 import { getLocaleAsync } from './getLocale';
@@ -9,7 +9,6 @@ Routing.setRoutingData(routes);
 export const getApiRoute = async (routeName, params) => {
   const { api_url, base: baseUrl } = context;
   let locale = await getLocaleAsync();
-  debug('-------------------- Api calling with ', locale);
   const serverName = `${api_url}`;
   params =
     'api_login_check' === routeName
@@ -19,6 +18,7 @@ export const getApiRoute = async (routeName, params) => {
   const url = `${serverName}${baseUrl}${Routing.generate(routeName, {
     ...params
   })}`;
+  //debug('API request:', url);
   return url;
 };
 

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -10,11 +10,15 @@ import { context } from '../config';
 
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
-    return response;
-  } else {
-    let error = new Error(response);
-    throw error;
+    if (!response.data || typeof response.data !== 'object') {
+      debug('API response is not an object:', typeof response.data, response.data);
+    } else {
+      //debug('API response:', response.data);
+      return response;
+    }
   }
+  let error = new Error(response);
+  throw error;
 }
 
 function onAPIError(error) {
@@ -118,7 +122,6 @@ export async function postRequest(
   recaptcha = false
 ) {
   let url = await getApiRoute(route, params);
-  debug(url);
   return await axios
     .post(url, data, await getHeaders(authenticated, recaptcha))
     .then(checkStatus)
@@ -173,7 +176,7 @@ export async function deleteAuthenticatedRequest(route, params) {
  * @param {endPoint} params
  */
 export async function getExternalRequest(params) {
-  debug('calling getexternal', params);
+  debug('getExternalRequest:', params);
   return await axios
     .get(params.endPoint)
     .then(checkStatus)

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -10,11 +10,16 @@ import { context } from '../config';
 
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
-    if (!response.data || typeof response.data !== 'object') {
-      debug('API response is not an object:', typeof response.data, response.data);
-    } else {
-      //debug('API response:', response.data);
+    if (response.status === 204) {
+      //debug('API response status:', response.status);
       return response;
+    } else {
+      if (!response.data || typeof response.data !== 'object') {
+        debug('API response is not an object:', typeof response.data, response.data);
+      } else {
+        //debug('API response:', response.data);
+        return response;
+      }
     }
   }
   let error = new Error(response);


### PR DESCRIPTION
Fixes #2480

Changes in this pull request:
- check if the API response contains a valid data object and throwing an error otherwise

As I generally added this check I will have to make sure:
- [x] Is every API call really returning a data object?
- [x] What happens if the API call throws an error? Is the error always handled correctly if no response data object exists?