### PR TITLE
add audience for auth0 authorization

### DIFF
--- a/app/actions/auth0Actions.js
+++ b/app/actions/auth0Actions.js
@@ -37,8 +37,8 @@ export function auth0OTP(email, code) {
       audience: 'urn:plant-for-the-planet',
     })
     .then(credentials => {
-      const { accessToken, idToken, refreshToken, expires_in } = credentials;
-      updateAuth0JWT(accessToken, refreshToken, idToken, expires_in);
+      const { accessToken, idToken, refreshToken } = credentials;
+      updateAuth0JWT(accessToken, refreshToken, idToken);
       return credentials;
     })
     .catch(error => {

--- a/app/actions/auth0Actions.js
+++ b/app/actions/auth0Actions.js
@@ -33,7 +33,8 @@ export function auth0OTP(email, code) {
     .loginWithEmail({
       email: email,
       code: code,
-      scope: 'offline_access'
+      scope: 'offline_access',
+      audience: 'urn:plant-for-the-planet',
     })
     .then(credentials => {
       const { accessToken, idToken, refreshToken } = credentials;

--- a/app/actions/auth0Actions.js
+++ b/app/actions/auth0Actions.js
@@ -37,8 +37,8 @@ export function auth0OTP(email, code) {
       audience: 'urn:plant-for-the-planet',
     })
     .then(credentials => {
-      const { accessToken, idToken, refreshToken } = credentials;
-      updateAuth0JWT(accessToken, refreshToken, idToken);
+      const { accessToken, idToken, refreshToken, expires_in } = credentials;
+      updateAuth0JWT(accessToken, refreshToken, idToken, expires_in);
       return credentials;
     })
     .catch(error => {

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -68,7 +68,7 @@ async function getHeaders(authenticated = false, recaptcha) {
     let auth0Token = await getAuth0AccessToken();
     if (auth0Token) {
       return {
-        headers: { ...headers, Authorization: `OAuth ${auth0Token}` }
+        headers: { ...headers, Authorization: `Bearer ${auth0Token}` }
       };
     } else {
       return {

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -122,8 +122,8 @@ const refreshAuth0TokenIfExpired = async () => {
     if (prev_refresh_token) {
       const credentials = await auth0NewAccessToken(prev_refresh_token);
       if (credentials) {
-        const { accessToken, idToken, refreshToken } = credentials;
-        updateAuth0JWT(accessToken, refreshToken, idToken);
+        const { accessToken, idToken, refreshToken, expires_in } = credentials;
+        updateAuth0JWT(accessToken, refreshToken, idToken, expires_in);
         return accessToken;
       }
     }
@@ -135,12 +135,16 @@ const refreshAuth0TokenIfExpired = async () => {
 // token - this is the access_token from Auth0
 // refresh_token - this is refresh token
 // id_token - this is the idToken used to get the expriration time
-export const updateAuth0JWT = (token, refreshToken, idToken) => {
+export const updateAuth0JWT = (token, refreshToken, idToken, expires_in) => {
   saveItem('auth0_token', token);
   // adds refreshToken to storage, if present
   if (refreshToken) {
     saveItem('auth0_refresh_token', refreshToken);
   }
-  saveItem('auth0_token_expires', `${getExpirationTimeStamp(idToken)}`);
+  if (idToken) {
+    saveItem('auth0_token_expires', `${getExpirationTimeStamp(idToken)}`);
+  } else if (expires_in) {
+    saveItem('auth0_token_expires', expires_in);
+  }
   return;
 };

--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -122,8 +122,8 @@ const refreshAuth0TokenIfExpired = async () => {
     if (prev_refresh_token) {
       const credentials = await auth0NewAccessToken(prev_refresh_token);
       if (credentials) {
-        const { accessToken, idToken, refreshToken, expires_in } = credentials;
-        updateAuth0JWT(accessToken, refreshToken, idToken, expires_in);
+        const { accessToken, idToken, refreshToken } = credentials;
+        updateAuth0JWT(accessToken, refreshToken, idToken);
         return accessToken;
       }
     }
@@ -135,7 +135,7 @@ const refreshAuth0TokenIfExpired = async () => {
 // token - this is the access_token from Auth0
 // refresh_token - this is refresh token
 // id_token - this is the idToken used to get the expriration time
-export const updateAuth0JWT = (token, refreshToken, idToken, expires_in) => {
+export const updateAuth0JWT = (token, refreshToken, idToken) => {
   saveItem('auth0_token', token);
   // adds refreshToken to storage, if present
   if (refreshToken) {
@@ -143,8 +143,8 @@ export const updateAuth0JWT = (token, refreshToken, idToken, expires_in) => {
   }
   if (idToken) {
     saveItem('auth0_token_expires', `${getExpirationTimeStamp(idToken)}`);
-  } else if (expires_in) {
-    saveItem('auth0_token_expires', expires_in);
+  } else {
+    saveItem('auth0_token_expires', `${getExpirationTimeStamp(token)}`);
   }
   return;
 };


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- add audience for auth0 authorization

This does not work very well as for a existing user the Auth0 call returned `The user does not exist` or for another one the backend API call returned `OAuth Token is invalid or expired `.

- [x] not existing user

<img width="1931" alt="Bildschirmfoto 2021-04-10 um 16 26 12" src="https://user-images.githubusercontent.com/1532418/114273317-dc8cb180-9a19-11eb-804a-ee0633fe6767.png">

- [x] Oauth expired or invalid

<img width="1940" alt="Bildschirmfoto 2021-04-10 um 16 27 17" src="https://user-images.githubusercontent.com/1532418/114273324-df87a200-9a19-11eb-9a84-479d8d225b7c.png">
