### PR TITLE
added support for slug of supported treecounter/profile

### DIFF
--- a/app/components/Competition/components/CompetitionParticipant.native.js
+++ b/app/components/Competition/components/CompetitionParticipant.native.js
@@ -18,7 +18,8 @@ class CompetitionParticipant extends React.Component {
   supportButton() {
     let supportObject = {
       id: this.props.competitor.treecounterId,
-      displayName: this.props.competitor.treecounterDisplayName
+      displayName: this.props.competitor.treecounterDisplayName,
+      slug: this.props.competitor.treecounterSlug,
     };
     this.props.supportTreecounterAction(supportObject);
     updateRoute('app_supportTrees', this.props.navigation, 55, {
@@ -120,14 +121,14 @@ class CompetitionParticipant extends React.Component {
               }
             >
               {this.props.competitor.treecounterSlug ===
-              this.props.treeCounter.slug
+                this.props.treeCounter.slug
                 ? i18n.t('label.me')
                 : this.props.competitor.treecounterDisplayName}
             </Text>
             {/* Competitor Name Ends */}
 
             {this.props.type === 'participants' ||
-            this.props.type === 'invite' ? (
+              this.props.type === 'invite' ? (
               <Text style={styles.topCompetitorScoreText}>
                 {this.props.competitor.score} {i18n.t('label.planted')}
               </Text>

--- a/app/components/Competition/components/CompetitionParticipant.native.js
+++ b/app/components/Competition/components/CompetitionParticipant.native.js
@@ -30,6 +30,7 @@ class CompetitionParticipant extends React.Component {
   }
   // This function is for participants to plant trees
   plantButton() {
+    this.props.clearSupport();
     updateRoute('app_donateTrees', this.props.navigation);
   }
   render() {
@@ -173,5 +174,6 @@ CompetitionParticipant.propTypes = {
   declinePart: PropTypes.any,
   cancelInvite: PropTypes.any,
   supportTreecounterAction: PropTypes.any,
+  clearSupport: PropTypes.any,
   navigation: PropTypes.any
 };

--- a/app/components/Competition/containers/SelectedCompetition.js
+++ b/app/components/Competition/containers/SelectedCompetition.js
@@ -15,7 +15,7 @@ import {
   invitePart,
   leaveCompetition
 } from './../redux/competitionActions';
-import { supportTreecounterAction } from '../../../actions/supportTreecounterAction';
+import { clearSupport, supportTreecounterAction } from '../../../actions/supportTreecounterAction';
 
 class SelectedCompetitionContainer extends Component {
   constructor(props) {
@@ -78,6 +78,7 @@ class SelectedCompetitionContainer extends Component {
           declinePart={id => this.props.declinePart(id)}
           cancelInvite={id => this.props.cancelInvite(id)}
           supportTreecounterAction={this.props.supportTreecounterAction}
+          clearSupport={this.props.clearSupport}
           currentUserProfile={this.props.userProfile}
           navigation={this.props.navigation}
           editCompetition={id => this.editCompetition(id)}
@@ -105,7 +106,8 @@ const mapDispatchToProps = dispatch => {
       declinePart,
       cancelInvite,
       invitePart,
-      supportTreecounterAction
+      supportTreecounterAction,
+      clearSupport,
     },
     dispatch
   );
@@ -124,6 +126,5 @@ SelectedCompetitionContainer.propTypes = {
   confirmPart: PropTypes.any,
   declinePart: PropTypes.any,
   cancelInvite: PropTypes.any,
-  supportTreecounterAction: PropTypes.any,
   editCompetition: PropTypes.any
 };

--- a/app/components/Competition/screens/SelectedCompetition.native.js
+++ b/app/components/Competition/screens/SelectedCompetition.native.js
@@ -254,11 +254,11 @@ class CompetitionFull extends React.Component {
                       >
                         {competitionDetail
                           ? i18n.t('label.comp_by_name', {
-                              compname:
-                                competitionDetail && competitionDetail.name,
-                              ownername:
-                                competitionDetail && competitionDetail.ownerName
-                            })
+                            compname:
+                              competitionDetail && competitionDetail.name,
+                            ownername:
+                              competitionDetail && competitionDetail.ownerName
+                          })
                           : null}
                       </Text>
                     </View>
@@ -287,8 +287,8 @@ class CompetitionFull extends React.Component {
                           <Text style={snippetStyles.bottomText}>
                             {competitionDetail &&
                               competitionDetail.contact +
-                                ', ' +
-                                competitionDetail &&
+                              ', ' +
+                              competitionDetail &&
                               competitionDetail.email}
                           </Text>
                         </View>
@@ -346,11 +346,11 @@ class CompetitionFull extends React.Component {
                         {competitionDetail.filterType === 'all'
                           ? i18n.t('label.if_all_project_msg')
                           : competitionDetail.filterType === 'donations'
-                          ? i18n.t('label.donation_only_msg')
-                          : competitionDetail.filterType === 'registered'
-                          ? i18n.t('label.register_only_msg')
-                          : null}
-                        {}
+                            ? i18n.t('label.donation_only_msg')
+                            : competitionDetail.filterType === 'registered'
+                              ? i18n.t('label.register_only_msg')
+                              : null}
+                        { }
                       </Text>
                       <Image
                         source={trees}
@@ -363,9 +363,10 @@ class CompetitionFull extends React.Component {
                     {competitionDetail.filterType === 'all' ? (
                       <TouchableOpacity
                         style={{ width: '100%' }}
-                        onPress={() =>
+                        onPress={() => {
+                          this.props.clearSupport();
                           navigation.navigate(getLocalRoute('app_donateTrees'))
-                        }
+                        }}
                       >
                         <Text style={snippetStyles.googleCardButton}>
                           {i18n.t('label.donate_now')}
@@ -374,9 +375,10 @@ class CompetitionFull extends React.Component {
                     ) : competitionDetail.filterType === 'donations' ? (
                       <TouchableOpacity
                         style={{ width: '100%' }}
-                        onPress={() =>
+                        onPress={() => {
+                          this.props.clearSupport();
                           navigation.navigate(getLocalRoute('app_donateTrees'))
-                        }
+                        }}
                       >
                         <Text style={snippetStyles.googleCardButton}>
                           {i18n.t('label.donate_now')}
@@ -435,6 +437,9 @@ class CompetitionFull extends React.Component {
                                 supportTreecounterAction={
                                   this.props.supportTreecounterAction
                                 }
+                                clearSupport={
+                                  this.props.clearSupport
+                                }
                                 key={index}
                                 status={status}
                                 competitionEnded={competitionEnded}
@@ -452,8 +457,8 @@ class CompetitionFull extends React.Component {
 
               {/* Participant Requests */}
               {requestCount > 0 &&
-              competitionDetail &&
-              competitionDetail.ownerTreecounterId ===
+                competitionDetail &&
+                competitionDetail.ownerTreecounterId ===
                 this.props.treeCounter.id ? (
                 <CardLayout style={[snippetStyles.projectSnippetContainerN]}>
                   <View style={snippetStyles.projectSpecsContainer}>
@@ -485,6 +490,9 @@ class CompetitionFull extends React.Component {
                                 supportTreecounterAction={
                                   this.props.supportTreecounterAction
                                 }
+                                clearSupport={
+                                  this.props.clearSupport
+                                }
                                 key={index}
                               />
                             ) : null
@@ -499,7 +507,7 @@ class CompetitionFull extends React.Component {
 
               {/* Invitation Details */}
               {competitionDetail &&
-              competitionDetail.ownerTreecounterId ===
+                competitionDetail.ownerTreecounterId ===
                 this.props.treeCounter.id ? (
                 <CardLayout style={[snippetStyles.projectSnippetContainerN]}>
                   <View style={snippetStyles.projectSpecsContainer}>
@@ -534,6 +542,9 @@ class CompetitionFull extends React.Component {
                                 supportTreecounterAction={
                                   this.props.supportTreecounterAction
                                 }
+                                clearSupport={
+                                  this.props.clearSupport
+                                }
                                 key={index}
                               />
                             ) : null
@@ -547,8 +558,8 @@ class CompetitionFull extends React.Component {
 
               {/* Invited Users */}
               {competitionDetail &&
-              invitedCount > 0 &&
-              competitionDetail.ownerTreecounterId !==
+                invitedCount > 0 &&
+                competitionDetail.ownerTreecounterId !==
                 this.props.treeCounter.id ? (
                 <CardLayout style={[snippetStyles.projectSnippetContainerN]}>
                   <View style={snippetStyles.projectSpecsContainer}>
@@ -562,7 +573,7 @@ class CompetitionFull extends React.Component {
                         {hasEnrollments &&
                           competitionDetail.allEnrollments.map((top, index) =>
                             top.status === 'invited' &&
-                            top.treecounterSlug ===
+                              top.treecounterSlug ===
                               this.props.treeCounter.slug ? (
                               <CompetitionParticipant
                                 competitor={top}
@@ -576,6 +587,9 @@ class CompetitionFull extends React.Component {
                                 cancelInvite={id => this.props.cancelInvite(id)}
                                 supportTreecounterAction={
                                   this.props.supportTreecounterAction
+                                }
+                                clearSupport={
+                                  this.props.clearSupport
                                 }
                                 key={index}
                               />
@@ -593,7 +607,7 @@ class CompetitionFull extends React.Component {
       </View>
     );
   }
-  componentWillUnmount() {}
+  componentWillUnmount() { }
 }
 
 const mapStateToProps = state => ({
@@ -625,5 +639,6 @@ CompetitionFull.propTypes = {
   declinePart: PropTypes.any,
   cancelInvite: PropTypes.any,
   supportTreecounterAction: PropTypes.any,
+  clearSupport: PropTypes.any,
   editCompetition: PropTypes.any
 };

--- a/app/components/PlantProjects/PlantProjectFull.native.js
+++ b/app/components/PlantProjects/PlantProjectFull.native.js
@@ -23,6 +23,7 @@ import { InAppBrowser } from "react-native-inappbrowser-reborn";
 import { getAuth0AccessToken } from "../../utils/user";
 // import TabContainer from '../../containers/Menu/TabContainer';
 import { getLocale } from '../../actions/getLocale';
+import { supportedTreecounterSelector } from '../../selectors';
 
 /**
  * see: https://github.com/Plant-for-the-Planet-org/treecounter-platform/wiki/Component-PlantProjectFull
@@ -92,6 +93,7 @@ class PlantProjectFull extends React.Component {
   render() {
     let { plantProject } = this.props;
 
+
     if (!plantProject || !plantProject.tpoData) return <LoadingIndicator />;
     //debug('rendering with project:', plantProject);
     const {
@@ -129,6 +131,7 @@ class PlantProjectFull extends React.Component {
     const backgroundColor = "white";
 
     const locale = getLocale();
+    const supportedSlug = this.props?.supportTreecounter?.slug;
 
     return !loader ? (
       <View style={{ flex: 1 }}>
@@ -151,7 +154,7 @@ class PlantProjectFull extends React.Component {
             "/" +
             this.props.plantProject.id
           }
-          //  appurl={'weplant://project/' + this.props.plantProject.id}
+        //  appurl={'weplant://project/' + this.props.plantProject.id}
         />
         <Animated.ScrollView
           contentContainerStyle={[
@@ -218,11 +221,11 @@ class PlantProjectFull extends React.Component {
                 getAuth0AccessToken().then(token => {
                   if (token) {
                     this.openWebView(
-                      `${planet_pay_url}/?to=${plantProject.slug}&locale=${locale}&token=${token}`
+                      `${planet_pay_url}/?to=${plantProject.slug}&s=${supportedSlug}&locale=${locale}&token=${token}`
                     );
                   } else {
                     this.openWebView(
-                      `${planet_pay_url}/?to=${plantProject.slug}&locale=${locale}`
+                      `${planet_pay_url}/?to=${plantProject.slug}&s=${supportedSlug}&locale=${locale}`
                     );
                   }
                 });
@@ -251,6 +254,12 @@ PlantProjectFull.propTypes = {
   onBackClick: PropTypes.func
 };
 
+const mapStateToProps = state => {
+  return {
+    supportTreecounter: supportedTreecounterSelector(state),
+  };
+};
+
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
@@ -259,4 +268,8 @@ const mapDispatchToProps = dispatch => {
     dispatch
   );
 };
-export default connect(null, mapDispatchToProps)(PlantProjectFull);
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PlantProjectFull);

--- a/app/components/PlantProjects/PlantProjectFull.native.js
+++ b/app/components/PlantProjects/PlantProjectFull.native.js
@@ -24,6 +24,7 @@ import { getAuth0AccessToken } from "../../utils/user";
 // import TabContainer from '../../containers/Menu/TabContainer';
 import { getLocale } from '../../actions/getLocale';
 import { supportedTreecounterSelector } from '../../selectors';
+import { clearSupport } from '../../actions/supportTreecounterAction';
 
 /**
  * see: https://github.com/Plant-for-the-Planet-org/treecounter-platform/wiki/Component-PlantProjectFull
@@ -82,6 +83,7 @@ class PlantProjectFull extends React.Component {
   openWebView = async link => {
     try {
       const url = link;
+      console.log("PlantProjectFull.native.js", link);
       if (await InAppBrowser.isAvailable()) {
         await InAppBrowser.open(url);
       } else Linking.openURL(url);
@@ -131,7 +133,7 @@ class PlantProjectFull extends React.Component {
     const backgroundColor = "white";
 
     const locale = getLocale();
-    const supportedSlug = this.props?.supportTreecounter?.slug;
+    const supportedSlug = this.props.supportTreecounter?.slug ? this.props.supportTreecounter.slug : '';
 
     return !loader ? (
       <View style={{ flex: 1 }}>
@@ -263,7 +265,8 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
-      loadProject
+      loadProject,
+      clearSupport
     },
     dispatch
   );

--- a/app/components/PlantProjects/PlantProjectSnippet.native.js
+++ b/app/components/PlantProjects/PlantProjectSnippet.native.js
@@ -34,7 +34,6 @@ import { bindActionCreators } from "redux";
 import { InAppBrowser } from "react-native-inappbrowser-reborn";
 import { getAuth0AccessToken } from '../../utils/user'
 import { getLocale } from '../../actions/getLocale';
-import { supportedTreecounterSelector } from '../../selectors';
 //keeping Icon here instead of in assets
 // const starIcon = <Icon name="star" size={14} color="#89b53a" />;
 
@@ -54,6 +53,7 @@ class PlantProjectSnippet extends PureComponent {
   openWebView = async link => {
     try {
       const url = link;
+      console.log("PlantProjectSnippet.native.js", link);
       if (await InAppBrowser.isAvailable()) {
         await InAppBrowser.open(url);
       } else Linking.openURL(url);
@@ -141,7 +141,6 @@ class PlantProjectSnippet extends PureComponent {
     let onPressHandler = this.props.clickable ? this.containerPress : undefined;
     const { planet_pay_url } = context;
     const locale = getLocale();
-    const supportedSlug = this.props?.supportTreecounter?.slug;
 
     return (
       <TouchableHighlight underlayColor={"white"} onPress={onPressHandler}>
@@ -313,10 +312,10 @@ class PlantProjectSnippet extends PureComponent {
                     getAuth0AccessToken().then(token => {
                       if (token) {
                         this.openWebView(
-                          `${planet_pay_url}/?to=${slug}&s=${supportedSlug}&locale=${locale}&token=${token}`
+                          `${planet_pay_url}/?to=${slug}&locale=${locale}&token=${token}`
                         );
                       } else {
-                        this.openWebView(`${planet_pay_url}/?to=${supportedSlug}&s=${slug}&locale=${locale}`);
+                        this.openWebView(`${planet_pay_url}/?to=${slug}&locale=${locale}`);
                       }
                     });
                   }}
@@ -389,12 +388,6 @@ PlantProjectSnippet.propTypes = {
   selectProject: PropTypes.func
 };
 
-const mapStateToProps = state => {
-  return {
-    supportTreecounter: supportedTreecounterSelector(state),
-  };
-};
-
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
@@ -405,6 +398,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(PlantProjectSnippet);

--- a/app/components/PlantProjects/PlantProjectSnippet.native.js
+++ b/app/components/PlantProjects/PlantProjectSnippet.native.js
@@ -32,8 +32,9 @@ import { selectPlantProjectAction } from "../../actions/selectPlantProjectAction
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { InAppBrowser } from "react-native-inappbrowser-reborn";
-import {getAuth0AccessToken} from '../../utils/user'
+import { getAuth0AccessToken } from '../../utils/user'
 import { getLocale } from '../../actions/getLocale';
+import { supportedTreecounterSelector } from '../../selectors';
 //keeping Icon here instead of in assets
 // const starIcon = <Icon name="star" size={14} color="#89b53a" />;
 
@@ -140,6 +141,7 @@ class PlantProjectSnippet extends PureComponent {
     let onPressHandler = this.props.clickable ? this.containerPress : undefined;
     const { planet_pay_url } = context;
     const locale = getLocale();
+    const supportedSlug = this.props?.supportTreecounter?.slug;
 
     return (
       <TouchableHighlight underlayColor={"white"} onPress={onPressHandler}>
@@ -288,8 +290,8 @@ class PlantProjectSnippet extends PureComponent {
                     <Text style={styles.survivalText}>
                       {specsProps.taxDeduction && specsProps.taxDeduction.length
                         ? `${i18n.t("label.tax_deductible")} ${i18n.t(
-                            "label.in"
-                          )} ${deducibleText1}`
+                          "label.in"
+                        )} ${deducibleText1}`
                         : i18n.t("label.no_tax_deduction")}
                     </Text>
                   </View>
@@ -311,10 +313,10 @@ class PlantProjectSnippet extends PureComponent {
                     getAuth0AccessToken().then(token => {
                       if (token) {
                         this.openWebView(
-                          `${planet_pay_url}/?to=${slug}&locale=${locale}&token=${token}`
+                          `${planet_pay_url}/?to=${slug}&s=${supportedSlug}&locale=${locale}&token=${token}`
                         );
                       } else {
-                        this.openWebView(`${planet_pay_url}/?to=${slug}&locale=${locale}`);
+                        this.openWebView(`${planet_pay_url}/?to=${supportedSlug}&s=${slug}&locale=${locale}`);
                       }
                     });
                   }}
@@ -386,6 +388,13 @@ PlantProjectSnippet.propTypes = {
   showCertifiedTag: PropTypes.bool,
   selectProject: PropTypes.func
 };
+
+const mapStateToProps = state => {
+  return {
+    supportTreecounter: supportedTreecounterSelector(state),
+  };
+};
+
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
@@ -394,4 +403,8 @@ const mapDispatchToProps = dispatch => {
     dispatch
   );
 };
-export default connect(null, mapDispatchToProps)(PlantProjectSnippet);
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PlantProjectSnippet);

--- a/app/components/PlantProjects/PlantProjectSnippet.native.js
+++ b/app/components/PlantProjects/PlantProjectSnippet.native.js
@@ -34,6 +34,7 @@ import { bindActionCreators } from "redux";
 import { InAppBrowser } from "react-native-inappbrowser-reborn";
 import { getAuth0AccessToken } from '../../utils/user'
 import { getLocale } from '../../actions/getLocale';
+import { supportedTreecounterSelector } from '../../selectors';
 //keeping Icon here instead of in assets
 // const starIcon = <Icon name="star" size={14} color="#89b53a" />;
 
@@ -141,6 +142,7 @@ class PlantProjectSnippet extends PureComponent {
     let onPressHandler = this.props.clickable ? this.containerPress : undefined;
     const { planet_pay_url } = context;
     const locale = getLocale();
+    const supportedSlug = this.props.supportTreecounter?.slug ? this.props.supportTreecounter.slug : '';
 
     return (
       <TouchableHighlight underlayColor={"white"} onPress={onPressHandler}>
@@ -312,10 +314,12 @@ class PlantProjectSnippet extends PureComponent {
                     getAuth0AccessToken().then(token => {
                       if (token) {
                         this.openWebView(
-                          `${planet_pay_url}/?to=${slug}&locale=${locale}&token=${token}`
+                          `${planet_pay_url}/?to=${slug}&s=${supportedSlug}&locale=${locale}&token=${token}`
                         );
                       } else {
-                        this.openWebView(`${planet_pay_url}/?to=${slug}&locale=${locale}`);
+                        this.openWebView(
+                          `${planet_pay_url}/?to=${supportedSlug}&s=${slug}&locale=${locale}`
+                        );
                       }
                     });
                   }}
@@ -388,6 +392,12 @@ PlantProjectSnippet.propTypes = {
   selectProject: PropTypes.func
 };
 
+const mapStateToProps = state => {
+  return {
+    supportTreecounter: supportedTreecounterSelector(state),
+  };
+};
+
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
@@ -398,6 +408,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(PlantProjectSnippet);

--- a/app/components/PublicTreeCounter/PublicTreecounter.native.js
+++ b/app/components/PublicTreeCounter/PublicTreecounter.native.js
@@ -341,33 +341,35 @@ class PublicTreeCounter extends React.Component {
             ) : null
           } */}
         </ScrollView>
-        <View
-          style={[
-            stylesPublicPage.bottomActionArea,
-            { position: 'absolute', bottom: 0, right: 0, left: 0 }
-          ]}
-        >
-          <Text style={[stylesPublicPage.supportUserText]}>
-            {i18n.t('label.supportUser', {
-              displayName: this.props.treecounter.displayName
-            })}
-          </Text>
-          <TouchableItem activeOpacity={0.6} onPress={this.onRegisterSupporter}>
-            <View style={stylesPublicPage.fullHeightButton}>
-              <Image
-                source={white_heart}
-                style={
-                  white_heart
-                    ? { width: 20, height: 20, marginRight: 12 }
-                    : { width: 0 }
-                }
-              />
-              <Text style={[stylesPublicPage.primaryButtonText]}>
-                {i18n.t('label.donate')}
-              </Text>
-            </View>
-          </TouchableItem>
-        </View>
+        {'tpo' !== userProfile.type ? (
+          <View
+            style={[
+              stylesPublicPage.bottomActionArea,
+              { position: 'absolute', bottom: 0, right: 0, left: 0 }
+            ]}
+          >
+            <Text style={[stylesPublicPage.supportUserText]}>
+              {i18n.t('label.supportUser', {
+                displayName: this.props.treecounter.displayName
+              })}
+            </Text>
+            <TouchableItem activeOpacity={0.6} onPress={this.onRegisterSupporter}>
+              <View style={stylesPublicPage.fullHeightButton}>
+                <Image
+                  source={white_heart}
+                  style={
+                    white_heart
+                      ? { width: 20, height: 20, marginRight: 12 }
+                      : { width: 0 }
+                  }
+                />
+                <Text style={[stylesPublicPage.primaryButtonText]}>
+                  {i18n.t('label.donate')}
+                </Text>
+              </View>
+            </TouchableItem>
+          </View>
+        ) : null}
       </SafeAreaView>
     );
   }

--- a/app/components/PublicTreeCounter/PublicTreecounter.native.js
+++ b/app/components/PublicTreeCounter/PublicTreecounter.native.js
@@ -58,6 +58,7 @@ class PublicTreeCounter extends React.Component {
 
   onPlantProjectSelected(selectedPlantProjectId) {
     //debug('on plant project seected', selectedPlantProjectId);
+    this.props.clearSupport();
     this.props.selectPlantProjectIdAction(selectedPlantProjectId);
     this.props.route('app_donateTrees');
   }
@@ -117,6 +118,7 @@ class PublicTreeCounter extends React.Component {
     }
   }
   onMoreClick(id, name) {
+    this.props.clearSupport();
     this.props.selectPlantProjectIdAction(id);
     const { navigation } = this.props;
     updateRoute('app_selectedProject', navigation, null, {
@@ -126,6 +128,7 @@ class PublicTreeCounter extends React.Component {
   }
 
   onSelectClickedFeaturedProjects = id => {
+    this.props.clearSupport();
     this.props.selectPlantProjectIdAction(id);
     const { navigation } = this.props;
     updateStaticRoute('app_donate_detail', navigation);
@@ -215,9 +218,9 @@ class PublicTreeCounter extends React.Component {
           </View>
           <View>
             {userProfile.synopsis1 ||
-            userProfile.synopsis2 ||
-            userProfile.linkText ||
-            userProfile.url ? (
+              userProfile.synopsis2 ||
+              userProfile.linkText ||
+              userProfile.url ? (
               <CardLayout>
                 {userProfile.synopsis1 ? (
                   <Text style={stylesHome.footerText}>
@@ -242,7 +245,7 @@ class PublicTreeCounter extends React.Component {
           </View>
           <View>
             {'tpo' === userProfile.type &&
-            1 <= tpoProps.plantProjects.length ? (
+              1 <= tpoProps.plantProjects.length ? (
               <View style={{ marginBottom: 20 }}>
                 {tpoProps.plantProjects.map(project => (
                   <PlantProjectSnippet
@@ -390,6 +393,7 @@ PublicTreeCounter.propTypes = {
   unfollowSubscribeAction: PropTypes.func,
   selectPlantProjectIdAction: PropTypes.func,
   supportTreecounterAction: PropTypes.func,
+  clearSupport: PropTypes.func,
   route: PropTypes.func,
   navigation: PropTypes.any
 };

--- a/app/components/PublicTreeCounter/PublicTreecounter.native.js
+++ b/app/components/PublicTreeCounter/PublicTreecounter.native.js
@@ -75,6 +75,9 @@ class PublicTreeCounter extends React.Component {
   UNSAFE_componentWillReceiveProps(nextProps) {
     const treecounter = nextProps.treecounter;
     if (treecounter) {
+      if ('tpo' === treecounter.userProfile.type) {
+        this.props.clearSupport();
+      }
       let svgData = {
         id: treecounter.id,
         target: treecounter.countTarget,
@@ -88,6 +91,7 @@ class PublicTreeCounter extends React.Component {
       this.setState({ svgData });
     }
   }
+
   updateSvg(toggle) {
     if (toggle) {
       const treecounter = this.props.treecounter;
@@ -117,6 +121,7 @@ class PublicTreeCounter extends React.Component {
       this.setState({ svgData: Object.assign({}, svgData) });
     }
   }
+
   onMoreClick(id, name) {
     this.props.clearSupport();
     this.props.selectPlantProjectIdAction(id);
@@ -133,6 +138,7 @@ class PublicTreeCounter extends React.Component {
     const { navigation } = this.props;
     updateStaticRoute('app_donate_detail', navigation);
   };
+
   render() {
     const { treecounter, currentUserProfile, navigation } = this.props;
     if (null === treecounter) {

--- a/app/containers/DonateTrees/index.js
+++ b/app/containers/DonateTrees/index.js
@@ -190,6 +190,7 @@ DonationTreesContainer.propTypes = {
   gift: PropTypes.func,
   fetchCurrencies: PropTypes.func,
   clearPlantProject: PropTypes.func,
+  clearSupport: PropTypes.object,
   supportTreecounter: PropTypes.object,
   setProgressModelState: PropTypes.func,
   loadUserProfile: PropTypes.func,

--- a/app/containers/DonateTrees/index.js
+++ b/app/containers/DonateTrees/index.js
@@ -7,7 +7,7 @@ import { createPaymentDonation, createPaymentGift, paymentClear } from '../../ac
 import { loadProject } from '../../actions/loadTposAction';
 import { loadUserProfile } from '../../actions/loadUserProfileAction';
 import { clearPlantProject, selectPlantProjectAction } from '../../actions/selectPlantProjectAction';
-import { supportTreecounterAction } from '../../actions/supportTreecounterAction';
+import { clearSupport, supportTreecounterAction } from '../../actions/supportTreecounterAction';
 import { updateUserProfile } from '../../actions/updateUserProfile';
 import DonateTrees from '../../components/DonateTrees';
 import { debug } from '../../debug';
@@ -94,11 +94,7 @@ class DonationTreesContainer extends PureComponent {
     ); */
     if (currentUserProfile) {
       currentUserProfile.supportedTreecounter &&
-        this.props.supportTreecounterAction({
-          id: null,
-          displayName: null,
-          slug: null,
-        });
+        this.props.clearSupport();
     }
   }
   onTabChange = title => this.props.navigation.setParams({ titleParam: title });
@@ -157,6 +153,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
+      clearSupport,
       supportTreecounterAction,
       selectPlantProjectAction,
       fetchCurrencies,

--- a/app/containers/DonateTrees/index.js
+++ b/app/containers/DonateTrees/index.js
@@ -33,7 +33,8 @@ class DonationTreesContainer extends PureComponent {
             _suggestions.data[0].type != 'tpo' && supportTreecounterAction({
               id: _suggestions.data[0].treecounterId,
               type: _suggestions.data[0].type,
-              displayName: _suggestions.data[0].name
+              displayName: _suggestions.data[0].name,
+              slug: _suggestions.data[0].slug,
             });
           }
         })
@@ -50,7 +51,8 @@ class DonationTreesContainer extends PureComponent {
           this.props.supportTreecounterAction({
             id: currentUserProfile.supportedTreecounter.id,
             type: currentUserProfile.supportedTreecounter.type,
-            displayName: currentUserProfile.supportedTreecounter.displayName
+            displayName: currentUserProfile.supportedTreecounter.displayName,
+            slug: currentUserProfile.supportedTreecounter.slug,
           });
       }
     }
@@ -94,7 +96,8 @@ class DonationTreesContainer extends PureComponent {
       currentUserProfile.supportedTreecounter &&
         this.props.supportTreecounterAction({
           id: null,
-          displayName: null
+          displayName: null,
+          slug: null,
         });
     }
   }

--- a/app/containers/Menu/NewBottomNavigator.js
+++ b/app/containers/Menu/NewBottomNavigator.js
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import {
   SafeAreaView,
   StyleSheet,
@@ -7,19 +8,24 @@ import {
   Text,
   TouchableOpacity
 } from 'react-native';
+import { bindActionCreators } from 'redux';
 //import { debug } from '../../debug';
 import StaticTabbar from './StaticTabbar';
 import i18n from '../../locales/i18n';
 import NetInfo from '@react-native-community/netinfo';
 import Icon from 'react-native-vector-icons/MaterialIcons';
+import { clearSupport } from '../../actions/supportTreecounterAction';
 
 let unsubscribe = null;
 
 // eslint-disable-next-line react/prefer-stateless-function
-export default class Tabbar extends React.PureComponent {
-  state = {
-    isConnected: true,
-  };
+class Tabbar extends PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      isConnected: true,
+    };
+  }
 
   checkInternet() {
     NetInfo.fetch().then(state => {
@@ -100,7 +106,11 @@ export default class Tabbar extends React.PureComponent {
               }
             ]}
           >
-            <StaticTabbar {...{ tabs }} navigation={this.props.navigation} />
+            <StaticTabbar
+              {...{ tabs }}
+              navigation={this.props.navigation}
+              onPressHook={(() => this.props.clearSupport())}
+            />
           </View>
           <View
             style={{
@@ -123,24 +133,24 @@ export default class Tabbar extends React.PureComponent {
         {this.state.isConnected ? (
           <SafeAreaView style={styles.container} />
         ) : (
-            <TouchableOpacity
-              onPress={() => this.checkInternet()}
-              style={{
-                width: '100%',
-                height: 48,
-                backgroundColor: '#bdc3c7',
-                justifyContent: 'center',
-                flexDirection: 'row',
-                alignItems: 'center'
-              }}
-            >
-              <Text style={[styles.noInternetText]}>
-                {i18n.t('label.noInternet')}
-              </Text>
-              <Icon name={'refresh'} size={18} color={'#353b48'} />
-              {/* <Text style={styles.noInternetText}>{i18n.t('label.someFunctionality')}</Text> */}
-            </TouchableOpacity>
-          )}
+          <TouchableOpacity
+            onPress={() => this.checkInternet()}
+            style={{
+              width: '100%',
+              height: 48,
+              backgroundColor: '#bdc3c7',
+              justifyContent: 'center',
+              flexDirection: 'row',
+              alignItems: 'center'
+            }}
+          >
+            <Text style={[styles.noInternetText]}>
+              {i18n.t('label.noInternet')}
+            </Text>
+            <Icon name={'refresh'} size={18} color={'#353b48'} />
+            {/* <Text style={styles.noInternetText}>{i18n.t('label.someFunctionality')}</Text> */}
+          </TouchableOpacity>
+        )}
       </>
     );
   }
@@ -158,3 +168,9 @@ const styles = StyleSheet.create({
     marginRight: 6
   }
 });
+
+const mapDispatchToProps = dispatch => {
+  return bindActionCreators({ clearSupport }, dispatch);
+};
+
+export default connect(null, mapDispatchToProps)(Tabbar);

--- a/app/containers/Menu/StaticTabbar.tsx
+++ b/app/containers/Menu/StaticTabbar.tsx
@@ -24,6 +24,8 @@ interface Tab {
 
 interface StaticTabbarProps {
   tabs: Tab[];
+  navigation: any,
+  onPressHook: Function,
 }
 
 export default class StaticTabbar extends React.PureComponent<
@@ -54,6 +56,10 @@ export default class StaticTabbar extends React.PureComponent<
     this.setState({
       selectedTab: index
     });
+    // call parent hook for pressing if available
+    if (this.props.onPressHook) {
+      this.props.onPressHook();
+    }
     updateRoute(tabs[index].route, this.props.navigation, 0);
   };
 

--- a/app/containers/PublicTreeCounterContainer/index.js
+++ b/app/containers/PublicTreeCounterContainer/index.js
@@ -6,7 +6,7 @@ import { updateRoute } from '../../helpers/routerHelper';
 import PublicTreecounter from '../../components/PublicTreeCounter/PublicTreecounter';
 import { currentUserProfileSelector } from '../../selectors';
 import { selectPlantProjectAction } from '../../actions/selectPlantProjectAction';
-import { supportTreecounterAction } from '../../actions/supportTreecounterAction';
+import { clearSupport, supportTreecounterAction } from '../../actions/supportTreecounterAction';
 import { followUser, unfollowUser } from '../../actions/followActions';
 import { treecounterLookupAction } from '../../actions/treecounterLookupAction';
 
@@ -66,6 +66,7 @@ class PublicTreecounterContainer extends Component {
         unfollowSubscribeAction={this.props.unfollowSubscribeAction}
         selectPlantProjectIdAction={this.props.selectPlantProjectIdAction}
         supportTreecounterAction={this.props.supportTreecounterAction}
+        clearSupport={this.props.clearSupport}
         navigation={this.props.navigation}
         route={(routeName, id, params) =>
           this.props.route(routeName, id, params, this.props.navigation)
@@ -79,6 +80,7 @@ const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
       selectPlantProjectIdAction: selectPlantProjectAction,
+      clearSupport: clearSupport,
       supportTreecounterAction: supportTreecounterAction,
       followSubscribeAction: followUser,
       unfollowSubscribeAction: unfollowUser,
@@ -108,6 +110,7 @@ PublicTreecounterContainer.propTypes = {
   followSubscribeAction: PropTypes.func,
   unfollowSubscribeAction: PropTypes.func,
   selectPlantProjectIdAction: PropTypes.func,
+  clearSupport: PropTypes.func,
   supportTreecounterAction: PropTypes.func,
   treecounterLookupAction: PropTypes.func,
   route: PropTypes.func,

--- a/app/reducers/supportedTreecounterReducer.js
+++ b/app/reducers/supportedTreecounterReducer.js
@@ -10,7 +10,8 @@ export const getSupportedTreecounter = state => state.supportedTreecounter;
 
 export const initialState = {
   treecounterId: null,
-  displayName: null
+  displayName: null,
+  slug: null,
 };
 
 const supportedTreecounterReducer = handleActions(
@@ -18,7 +19,8 @@ const supportedTreecounterReducer = handleActions(
     [setSupportedTreecounter]: (state, action) => ({
       treecounterId: action.payload.id,
       type: action.payload.type,
-      displayName: action.payload.displayName
+      displayName: action.payload.displayName,
+      slug: action.payload.slug,
     }),
     [clearSupportedTreecounter]: () => initialState
   },


### PR DESCRIPTION
Fixes #2908 by not showing big donate button for TPO treecounter.

This is a branch on top of #3057

Changes in this pull request:
- use supported treecounter slug from state as `s` query parameter for payment

To-Do:
- [x] If this state is once set, if it not cleared any more, so how to decide if it's wanted or not?
- [x] Why does `s=sagar-aryal` works, but `s=weforest` not? -> do not show support button for TPO treecounter
- [x] Ignored Pledge events code for now
- [ ] Can not distinct between support link for TPO and other profiles in competitions. Support links for TPOs do not work.
