### PR TITLE
changed project share link to website url

### DIFF
--- a/app/components/PlantProjects/PlantProjectFull.native.js
+++ b/app/components/PlantProjects/PlantProjectFull.native.js
@@ -165,9 +165,8 @@ class PlantProjectFull extends React.Component {
             context.scheme +
             "://" +
             context.host +
-            getLocalRoute("app_selectedProject") +
             "/" +
-            this.props.plantProject.id
+            this.props.plantProject.slug
           }
         //  appurl={'weplant://project/' + this.props.plantProject.id}
         />

--- a/app/components/PlantProjects/PlantProjectFull.native.js
+++ b/app/components/PlantProjects/PlantProjectFull.native.js
@@ -119,9 +119,11 @@ class PlantProjectFull extends React.Component {
       plantProjectImages,
       url,
       linkText,
-      tpoName,
       ndviUid
     } = plantProject;
+
+    const tpoName = plantProject.tpoName || plantProject.tpoData?.name;
+
     const { loader } = this.state;
     let tpo = plantProject.tpoData || {};
     const { planet_pay_url } = context;


### PR DESCRIPTION
Fixes #3075

Changes in this pull request:
- changed project share link to website url
- fixed error of missing `tpoName` in share link

@sagararyal this changes the link text from e.g. 

`Pflanzen Sie Bäume mit Plant-for-the-Planet unter https://development.trilliontreecampaign.org/project/1`

to

`Pflanzen Sie Bäume mit Plant-for-the-Planet unter https://www.trilliontreecampaign.org/yucatan`

so that opening this link as a deep link in the app will not work anymore, but is only more shown as a website.