### PR TITLE
let the auth token expire 5 minutes earlier to force an early renewal

### DIFF
--- a/app/utils/user.js
+++ b/app/utils/user.js
@@ -71,7 +71,8 @@ const refreshTokenIfExpired = async () => {
  */
 const tokenIsExpired = async (isAuth0 = false) => {
   let tokenExpiry = await getTokenExpires(isAuth0);
-  let expired = getCurrentUnixTimestamp() > tokenExpiry;
+  // let the token expire 5 minutes before it actually expires
+  let expired = (getCurrentUnixTimestamp() + 300) > tokenExpiry;
   return expired;
 };
 


### PR DESCRIPTION
Fixes #3090

Changes in this pull request:
- let the auth token expire 5 minutes earlier to force an early renewal