### PR TITLE
Update Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -23,6 +24,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
+        mavenCentral()
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -32,9 +35,8 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-        google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
+        jcenter()
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,4 +22,4 @@ android.useAndroidX = true
 android.enableJetifier = true
 org.gradle.jvmargs=-Xmx2048m
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.62.0
+FLIPPER_VERSION=0.87.0


### PR DESCRIPTION
Fixes broken Android build process

Changes in this pull request:
- added mavenCentral to replace jcenter
- updated Flipper to newer version
